### PR TITLE
Strip double quotes from emitted strings

### DIFF
--- a/lib/piper/ast/chars/literals_chars.ex
+++ b/lib/piper/ast/chars/literals_chars.ex
@@ -13,12 +13,8 @@ defimpl String.Chars, for: [Piper.Ast.String] do
 
   alias Piper.Ast
 
-  def to_string(%Ast.String{raw: raw, value: value}) do
-    if raw == nil do
-      value
-    else
-      raw
-    end
+  def to_string(%Ast.String{value: value}) do
+    value
   end
 
 end

--- a/lib/piper/ast/invocation.ex
+++ b/lib/piper/ast/invocation.ex
@@ -5,7 +5,7 @@ defmodule Piper.Ast.Invocation do
 
   defstruct [line: nil, col: nil, command: nil, args: [], options: []]
 
-  def new(%Token{type: :name}=token) do
+  def new(%Token{type: :string}=token) do
     %__MODULE__{line: token.line, col: token.col,
                 command: token.text}
   end

--- a/lib/piper/ast/literals.ex
+++ b/lib/piper/ast/literals.ex
@@ -69,16 +69,16 @@ end
 
 defmodule Piper.Ast.String do
 
-  defstruct [:line, :col, :value, :raw]
+  defstruct [:line, :col, :value]
 
   alias Piper.Util.Token
 
-  def new(%Token{line: line, col: col, text: text, raw: raw}) do
-    %__MODULE__{line: line, col: col, value: text, raw: raw}
+  def new(%Token{line: line, col: col, text: text}) do
+    %__MODULE__{line: line, col: col, value: text}
   end
 
   def new(line, col, text) do
-    %__MODULE__{line: line, col: col, value: text, raw: text}
+    %__MODULE__{line: line, col: col, value: text}
   end
 end
 

--- a/lib/piper/ast/option.ex
+++ b/lib/piper/ast/option.ex
@@ -5,17 +5,15 @@ defmodule Piper.Ast.Option do
   alias Piper.Ast
   alias Piper.Util.Token
 
-  def new(%Token{line: line, col: col, text: text, type: :option}) do
+  def new(%Token{line: line, col: col, text: text, type: type}) when type in [:string, :integer] do
     %__MODULE__{line: line, col: col, flag: text}
   end
-  def new(%Token{line: line, col: col, type: :optvar}=token) do
-    var = Ast.Variable.new(token)
-    %__MODULE__{line: line, col: col, flag: var}
+  def new(%Ast.Variable{}=var) do
+    %__MODULE__{line: var.line, col: var.col, flag: var}
   end
 
-
   def set_value(%__MODULE__{}=opt, value) do
-    %{opt | value: value}
+    opt = %{opt | value: value}
   end
 
 end

--- a/lib/piper/bind/literals.ex
+++ b/lib/piper/bind/literals.ex
@@ -19,11 +19,7 @@ defimpl Piper.Bindable, for: [Piper.Ast.String] do
   end
 
   def bind(literal, scope) do
-    if literal.raw != nil do
-      {:ok, literal.raw, scope}
-    else
-      {:ok, literal.value, scope}
-    end
+    {:ok, literal.value, scope}
   end
 
 end

--- a/lib/piper/syntax_error.ex
+++ b/lib/piper/syntax_error.ex
@@ -26,7 +26,7 @@ defmodule Piper.SyntaxError do
       fn(key, wrong_type) ->
         v1 = Map.get(wrong_type, key)
         v2 = Keyword.fetch!(new_opts, key)
-        Map.set(wrong_type, key, update_wrong_type(key, v1, v2))
+        Map.put(wrong_type, key, update_wrong_type(key, v1, v2))
       end)
   end
 

--- a/test/exec/bind_test.exs
+++ b/test/exec/bind_test.exs
@@ -46,8 +46,8 @@ defmodule Bind.BindTest do
   test "preparing simple command" do
     {:ok, ast} = parse_and_bind("echo 'foo'")
     assert ast.command == "echo"
-    assert arg(ast, 0) == "'foo'"
-    assert "#{ast}" == "echo 'foo'"
+    assert arg(ast, 0) == "foo"
+    assert "#{ast}" == "echo foo"
   end
 
   test "preparing command with options" do

--- a/test/parser/lexer_test.exs
+++ b/test/parser/lexer_test.exs
@@ -18,19 +18,19 @@ defmodule Parser.LexerTest do
   end
 
   test "lexing plain command" do
-    assert matches Lexer.tokenize("echo"), types(:name)
+    assert matches Lexer.tokenize("echo"), types(:string)
   end
 
   test "lexing hyphenated command" do
-    assert matches Lexer.tokenize("list-vms"), [types(:name), text("list-vms")]
+    assert matches Lexer.tokenize("list-vms"), [types(:string), text("list-vms")]
   end
 
   test "lexing command with underscore" do
-    assert matches Lexer.tokenize("list_vms"), [types(:name), text("list_vms")]
+    assert matches Lexer.tokenize("list_vms"), [types(:string), text("list_vms")]
   end
 
   test "lexing invalid commands results in non-name results" do
-    assert matches Lexer.tokenize("1list_vms"), [types([:integer, :name]), text(["1", "list_vms"])]
+    assert matches Lexer.tokenize("1list_vms"), [types([:integer, :string]), text(["1", "list_vms"])]
   end
 
   test "lexing numbers" do
@@ -42,8 +42,8 @@ defmodule Parser.LexerTest do
     assert matches Lexer.tokenize("true TRUE #t false FALSE #f TrUe FAlse trUE fAlse"), [types([:bool, :bool, :bool,
                                                                                                 :bool, :bool, :bool,
                                                                                                 :string, :string,
-                                                                                                :name, :name])]
-    assert matches Lexer.tokenize("echo true false \"testing\""), [types([:name, :bool, :bool, :string])]
+                                                                                                :string, :string])]
+    assert matches Lexer.tokenize("echo true false \"testing\""), [types([:string, :bool, :bool, :quoted_string])]
   end
 
   test "lexing plain variables" do
@@ -53,152 +53,152 @@ defmodule Parser.LexerTest do
   end
 
   test "lexing option variable" do
-    assert matches Lexer.tokenize("--$abc"), [types(:optvar), text("abc")]
-    assert matches Lexer.tokenize("-$abc"), [types(:optvar), text("abc")]
-    assert matches Lexer.tokenize("--$ABC"), [types(:optvar), text("ABC")]
-    assert matches Lexer.tokenize("-$ABC"), [types(:optvar), text("ABC")]
-    assert matches Lexer.tokenize("--$AbC12"), [types(:optvar), text("AbC12")]
-    assert matches Lexer.tokenize("-$AbC12"), [types(:optvar), text("AbC12")]
-    assert matches Lexer.tokenize("-$A"), [types(:optvar), text("A")]
+    assert matches Lexer.tokenize("--$abc"), [types([:option, :variable]), text(["--", "abc"])]
+    assert matches Lexer.tokenize("-$abc"), [types([:option, :variable]), text(["-", "abc"])]
+    assert matches Lexer.tokenize("--$ABC"), [types([:option, :variable]), text(["--", "ABC"])]
+    assert matches Lexer.tokenize("-$ABC"), [types([:option, :variable]), text(["-", "ABC"])]
+    assert matches Lexer.tokenize("--$AbC12"), [types([:option, :variable]), text(["--", "AbC12"])]
+    assert matches Lexer.tokenize("-$AbC12"), [types([:option, :variable]), text(["-", "AbC12"])]
+    assert matches Lexer.tokenize("-$A"), [types([:option, :variable]), text(["-", "A"])]
   end
 
   test "lexing long numeric options" do
-    assert matches Lexer.tokenize("--foo=123"), [types([:option, :equals, :integer]),
-                                                 text(["foo", "=", "123"])]
-    assert matches Lexer.tokenize("--foo=123.33"), [types([:option, :equals, :float]),
-                                                    text(["foo", "=", "123.33"])]
+    assert matches Lexer.tokenize("--foo=123"), [types([:option, :string, :equals, :integer]),
+                                                 text(["--", "foo", "=", "123"])]
+    assert matches Lexer.tokenize("--foo=123.33"), [types([:option, :string, :equals, :float]),
+                                                    text(["--", "foo", "=", "123.33"])]
   end
 
   test "lexing long string-like options" do
-    assert matches Lexer.tokenize("--foo=abc"), [types([:option, :equals, :name]),
-                                                 text(["foo", "=", "abc"])]
-    assert matches Lexer.tokenize("--foo=\"foo@bar\""), [types([:option, :equals, :string]),
-                                                         text(["foo", "=", "foo@bar"])]
-    assert matches Lexer.tokenize("--foo='foo bar'"), [types([:option, :equals, :string]),
-                                                       text(["foo", "=", "foo bar"])]
-    assert matches Lexer.tokenize("--foo=test:test"), [types([:option, :equals, :name, :colon, :name]),
-                                                       text(["foo", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("--foo=abc"), [types([:option, :string, :equals, :string]),
+                                                 text(["--", "foo", "=", "abc"])]
+    assert matches Lexer.tokenize("--foo=\"foo@bar\""), [types([:option, :string, :equals, :quoted_string]),
+                                                         text(["--", "foo", "=", "foo@bar"])]
+    assert matches Lexer.tokenize("--foo='foo bar'"), [types([:option, :string, :equals, :quoted_string]),
+                                                       text(["--", "foo", "=", "foo bar"])]
+    assert matches Lexer.tokenize("--foo=test:test"), [types([:option, :string, :equals, :string, :colon, :string]),
+                                                       text(["--", "foo", "=", "test", ":", "test"])]
   end
 
   test "lexing long variable options" do
-    assert matches Lexer.tokenize("--foo=$bar"), [types([:option, :equals, :variable]),
-                                                  text(["foo", "=", "bar"])]
+    assert matches Lexer.tokenize("--foo=$bar"), [types([:option, :string, :equals, :variable]),
+                                                  text(["--", "foo", "=", "bar"])]
   end
 
   test "lexing long numeric optvars" do
-    assert matches Lexer.tokenize("--$foo=123"), [types([:optvar, :equals, :integer]),
-                                                 text(["foo", "=", "123"])]
-    assert matches Lexer.tokenize("--$foo=123.33"), [types([:optvar, :equals, :float]),
-                                                     text(["foo", "=", "123.33"])]
+    assert matches Lexer.tokenize("--$foo=123"), [types([:option, :variable, :equals, :integer]),
+                                                 text(["--", "foo", "=", "123"])]
+    assert matches Lexer.tokenize("--$foo=123.33"), [types([:option, :variable, :equals, :float]),
+                                                     text(["--", "foo", "=", "123.33"])]
   end
 
   test "lexing long string-like optvars" do
-    assert matches Lexer.tokenize("--$foo=abc"), [types([:optvar, :equals, :name]),
-                                                 text(["foo", "=", "abc"])]
-    assert matches Lexer.tokenize("--$foo=\"foo@bar\""), [types([:optvar, :equals, :string]),
-                                                         text(["foo", "=", "foo@bar"])]
-    assert matches Lexer.tokenize("--$foo='foo bar'"), [types([:optvar, :equals, :string]),
-                                                       text(["foo", "=", "foo bar"])]
-    assert matches Lexer.tokenize("--$foo=test:test"), [types([:optvar, :equals, :name, :colon, :name]),
-                                                        text(["foo", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("--$foo=abc"), [types([:option, :variable, :equals, :string]),
+                                                 text(["--", "foo", "=", "abc"])]
+    assert matches Lexer.tokenize("--$foo=\"foo@bar\""), [types([:option, :variable, :equals, :quoted_string]),
+                                                         text(["--", "foo", "=", "foo@bar"])]
+    assert matches Lexer.tokenize("--$foo='foo bar'"), [types([:option, :variable, :equals, :quoted_string]),
+                                                       text(["--", "foo", "=", "foo bar"])]
+    assert matches Lexer.tokenize("--$foo=test:test"), [types([:option, :variable, :equals, :string, :colon, :string]),
+                                                        text(["--", "foo", "=", "test", ":", "test"])]
   end
 
   test "lexing long variable optvars" do
-    assert matches Lexer.tokenize("--$foo=$bar"), [types([:optvar, :equals, :variable]),
-                                                   text(["foo", "=", "bar"])]
+    assert matches Lexer.tokenize("--$foo=$bar"), [types([:option, :variable, :equals, :variable]),
+                                                   text(["--", "foo", "=", "bar"])]
   end
 
   test "lexing short numeric options" do
-    assert matches Lexer.tokenize("-f 123"), [types([:option, :integer]),
-                                              text(["f", "123"])]
-    assert matches Lexer.tokenize("-f 123.33"), [types([:option, :float]),
-                                                 text(["f", "123.33"])]
+    assert matches Lexer.tokenize("-f 123"), [types([:option, :string, :integer]),
+                                              text(["-", "f", "123"])]
+    assert matches Lexer.tokenize("-f 123.33"), [types([:option, :string, :float]),
+                                                 text(["-", "f", "123.33"])]
   end
 
   test "lexing short string-like options" do
-    assert matches Lexer.tokenize("-f abc"), [types([:option, :name]),
-                                              text(["f", "abc"])]
-    assert matches Lexer.tokenize("-f \"foo@bar\""), [types([:option, :string]),
-                                                      text(["f", "foo@bar"])]
-    assert matches Lexer.tokenize("-f 'foo bar'"), [types([:option, :string]),
-                                                       text(["f", "foo bar"])]
-    assert matches Lexer.tokenize("-f test:test"), [types([:option, :name, :colon, :name]),
-                                                    text(["f", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-f abc"), [types([:option, :string, :string]),
+                                              text(["-", "f", "abc"])]
+    assert matches Lexer.tokenize("-f \"foo@bar\""), [types([:option, :string, :quoted_string]),
+                                                      text(["-", "f", "foo@bar"])]
+    assert matches Lexer.tokenize("-f 'foo bar'"), [types([:option, :string, :quoted_string]),
+                                                       text(["-", "f", "foo bar"])]
+    assert matches Lexer.tokenize("-f test:test"), [types([:option, :string, :string, :colon, :string]),
+                                                    text(["-", "f", "test", ":", "test"])]
   end
 
   test "lexing short variable options" do
-    assert matches Lexer.tokenize("-f $bar"), [types([:option, :variable]),
-                                                    text(["f", "bar"])]
+    assert matches Lexer.tokenize("-f $bar"), [types([:option, :string, :variable]),
+                                                    text(["-", "f", "bar"])]
 
   end
 
   test "lexing short options with assigned numeric values" do
-    assert matches Lexer.tokenize("-f=123"), [types([:option, :equals, :integer]),
-                                              text(["f", "=", "123"])]
-    assert matches Lexer.tokenize("-f=123.33"), [types([:option, :equals, :float]),
-                                                 text(["f", "=", "123.33"])]
+    assert matches Lexer.tokenize("-f=123"), [types([:option, :string, :equals, :integer]),
+                                              text(["-", "f", "=", "123"])]
+    assert matches Lexer.tokenize("-f=123.33"), [types([:option, :string, :equals, :float]),
+                                                 text(["-", "f", "=", "123.33"])]
   end
 
   test "lexing short options with assigned string-like values" do
-    assert matches Lexer.tokenize("-f=abc"), [types([:option, :equals, :name]),
-                                              text(["f", "=", "abc"])]
-    assert matches Lexer.tokenize("-f=\"foo@bar\""), [types([:option, :equals, :string]),
-                                                      text(["f", "=", "foo@bar"])]
-    assert matches Lexer.tokenize("-f='foo bar'"), [types([:option, :equals, :string]),
-                                                       text(["f", "=", "foo bar"])]
-    assert matches Lexer.tokenize("-f=test:test"), [types([:option, :equals, :name, :colon, :name]),
-                                                    text(["f", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-f=abc"), [types([:option, :string, :equals, :string]),
+                                              text(["-", "f", "=", "abc"])]
+    assert matches Lexer.tokenize("-f=\"foo@bar\""), [types([:option, :string, :equals, :quoted_string]),
+                                                      text(["-", "f", "=", "foo@bar"])]
+    assert matches Lexer.tokenize("-f='foo bar'"), [types([:option, :string, :equals, :quoted_string]),
+                                                       text(["-", "f", "=", "foo bar"])]
+    assert matches Lexer.tokenize("-f=test:test"), [types([:option, :string, :equals, :string, :colon, :string]),
+                                                    text(["-", "f", "=", "test", ":", "test"])]
   end
 
   test "lexing short options with assigned variable values" do
-    assert matches Lexer.tokenize("-f=$bar"), [types([:option, :equals, :variable]),
-                                                    text(["f", "=", "bar"])]
+    assert matches Lexer.tokenize("-f=$bar"), [types([:option, :string, :equals, :variable]),
+                                                    text(["-", "f", "=", "bar"])]
   end
 
   test "lexing short numeric optvars" do
-    assert matches Lexer.tokenize("-$f 123"), [types([:optvar, :integer]),
-                                              text(["f", "123"])]
-    assert matches Lexer.tokenize("-$f 123.33"), [types([:optvar, :float]),
-                                                  text(["f", "123.33"])]
+    assert matches Lexer.tokenize("-$f 123"), [types([:option, :variable, :integer]),
+                                              text(["-", "f", "123"])]
+    assert matches Lexer.tokenize("-$f 123.33"), [types([:option, :variable, :float]),
+                                                  text(["-", "f", "123.33"])]
   end
 
   test "lexing short string-like optvars" do
-    assert matches Lexer.tokenize("-$f abc"), [types([:optvar, :name]),
-                                              text(["f", "abc"])]
-    assert matches Lexer.tokenize("-$f \"foo@bar\""), [types([:optvar, :string]),
-                                                      text(["f", "foo@bar"])]
-    assert matches Lexer.tokenize("-$f 'foo bar'"), [types([:optvar, :string]),
-                                                       text(["f", "foo bar"])]
-    assert matches Lexer.tokenize("-$f test:test"), [types([:optvar, :name, :colon, :name]),
-                                                       text(["f", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-$f abc"), [types([:option, :variable, :string]),
+                                              text(["-", "f", "abc"])]
+    assert matches Lexer.tokenize("-$f \"foo@bar\""), [types([:option, :variable, :quoted_string]),
+                                                      text(["-", "f", "foo@bar"])]
+    assert matches Lexer.tokenize("-$f 'foo bar'"), [types([:option, :variable, :quoted_string]),
+                                                       text(["-", "f", "foo bar"])]
+    assert matches Lexer.tokenize("-$f test:test"), [types([:option, :variable, :string, :colon, :string]),
+                                                       text(["-", "f", "test", ":", "test"])]
   end
 
   test "lexing short variable optvars" do
-    assert matches Lexer.tokenize("-$f $bar"), [types([:optvar, :variable]),
-                                                text(["f", "bar"])]
+    assert matches Lexer.tokenize("-$f $bar"), [types([:option, :variable, :variable]),
+                                                text(["-", "f", "bar"])]
   end
 
   test "lexing short optvars with assigned numeric values" do
-    assert matches Lexer.tokenize("-$f=123"), [types([:optvar, :equals, :integer]),
-                                               text(["f", "=", "123"])]
-    assert matches Lexer.tokenize("-$f=123.33"), [types([:optvar, :equals, :float]),
-                                                  text(["f", "=", "123.33"])]
+    assert matches Lexer.tokenize("-$f=123"), [types([:option, :variable, :equals, :integer]),
+                                               text(["-", "f", "=", "123"])]
+    assert matches Lexer.tokenize("-$f=123.33"), [types([:option, :variable, :equals, :float]),
+                                                  text(["-", "f", "=", "123.33"])]
   end
 
   test "lexing short optvars with assigned string-like values" do
-    assert matches Lexer.tokenize("-$f=abc"), [types([:optvar, :equals, :name]),
-                                              text(["f", "=", "abc"])]
-    assert matches Lexer.tokenize("-$f=\"foo@bar\""), [types([:optvar, :equals, :string]),
-                                                      text(["f", "=", "foo@bar"])]
-    assert matches Lexer.tokenize("-$f='foo bar'"), [types([:optvar, :equals, :string]),
-                                                       text(["f", "=", "foo bar"])]
-    assert matches Lexer.tokenize("-$f=test:test"), [types([:optvar, :equals, :name, :colon, :name]),
-                                                       text(["f", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-$f=abc"), [types([:option, :variable, :equals, :string]),
+                                              text(["-", "f", "=", "abc"])]
+    assert matches Lexer.tokenize("-$f=\"foo@bar\""), [types([:option, :variable, :equals, :quoted_string]),
+                                                      text(["-", "f", "=", "foo@bar"])]
+    assert matches Lexer.tokenize("-$f='foo bar'"), [types([:option, :variable, :equals, :quoted_string]),
+                                                       text(["-", "f", "=", "foo bar"])]
+    assert matches Lexer.tokenize("-$f=test:test"), [types([:option, :variable, :equals, :string, :colon, :string]),
+                                                       text(["-", "f", "=", "test", ":", "test"])]
   end
 
   test "lexing short optvars with assigned variable value" do
-    assert matches Lexer.tokenize("-$f=$bar"), [types([:optvar, :equals, :variable]),
-                                                text(["f", "=", "bar"])]
+    assert matches Lexer.tokenize("-$f=$bar"), [types([:option, :variable, :equals, :variable]),
+                                                text(["-", "f", "=", "bar"])]
   end
 
   test "lexing correct json" do
@@ -211,47 +211,47 @@ defmodule Parser.LexerTest do
   end
 
   test "lexing single-quoted strings" do
-    assert matches Lexer.tokenize("'this is a test'"), [types(:string), text("this is a test")]
+    assert matches Lexer.tokenize("'this is a test'"), [types(:quoted_string), text("this is a test")]
   end
 
   test "lexing double-quoted strings" do
-    assert matches Lexer.tokenize("\"this is a test\""), [types(:string), text("this is a test")]
+    assert matches Lexer.tokenize("\"this is a test\""), [types(:quoted_string), text("this is a test")]
   end
 
   test "lexing mixed quotes" do
-    assert matches Lexer.tokenize("'\"this is a test\"'"), [types(:string), text("\"this is a test\"")]
-    assert matches Lexer.tokenize("\"'this is a test'\""), [types(:string), text("'this is a test'")]
+    assert matches Lexer.tokenize("'\"this is a test\"'"), [types(:quoted_string), text("\"this is a test\"")]
+    assert matches Lexer.tokenize("\"'this is a test'\""), [types(:quoted_string), text("'this is a test'")]
   end
 
   test "lexing escaped quotes" do
-    assert matches Lexer.tokenize("\"this is a \\\"test\\\"\""), [types(:string), text("this is a \"test\"")]
-    assert matches Lexer.tokenize("'this is a \\'test\\''"), [types(:string), text("this is a 'test'")]
+    assert matches Lexer.tokenize("\"this is a \\\"test\\\"\""), [types(:quoted_string), text("this is a \"test\"")]
+    assert matches Lexer.tokenize("'this is a \\'test\\''"), [types(:quoted_string), text("this is a 'test'")]
   end
 
   test "lexing quoted terms returns strings" do
-    assert matches Lexer.tokenize("\"123\""), [types([:string]), text("123")]
-    assert matches Lexer.tokenize("\"0.05\""), [types([:string]), text("0.05")]
-    assert matches Lexer.tokenize("'123'"), [types([:string]), text("123")]
-    assert matches Lexer.tokenize("'$abc_def'"), [types([:string]), text("$abc_def")]
-    assert matches Lexer.tokenize("'$ab3_Def'"), [types([:string]), text("$ab3_Def")]
+    assert matches Lexer.tokenize("\"123\""), [types([:quoted_string]), text("123")]
+    assert matches Lexer.tokenize("\"0.05\""), [types([:quoted_string]), text("0.05")]
+    assert matches Lexer.tokenize("'123'"), [types([:quoted_string]), text("123")]
+    assert matches Lexer.tokenize("'$abc_def'"), [types([:quoted_string]), text("$abc_def")]
+    assert matches Lexer.tokenize("'$ab3_Def'"), [types([:quoted_string]), text("$ab3_Def")]
   end
 
   test "single-quoted terms remain separate" do
-    assert matches Lexer.tokenize("'abc' 'def' '1231'"), [types([:string, :string, :string]),
+    assert matches Lexer.tokenize("'abc' 'def' '1231'"), [types([:quoted_string, :quoted_string, :quoted_string]),
                                                           text(["abc", "def", "1231"])]
-    assert matches Lexer.tokenize("'abc''def''1231'"), [types([:string, :string, :string]),
+    assert matches Lexer.tokenize("'abc''def''1231'"), [types([:quoted_string, :quoted_string, :quoted_string]),
                                                         text(["abc", "def", "1231"])]
   end
 
   test "double-quoted terms remain separate" do
-    assert matches Lexer.tokenize("\"abc\" \"def\" \"1231\""), [types([:string, :string, :string]),
+    assert matches Lexer.tokenize("\"abc\" \"def\" \"1231\""), [types([:quoted_string, :quoted_string, :quoted_string]),
                                                                 text(["abc", "def", "1231"])]
-    assert matches Lexer.tokenize("\"abc\"\"def\"\"1231\""), [types([:string, :string, :string]),
+    assert matches Lexer.tokenize("\"abc\"\"def\"\"1231\""), [types([:quoted_string, :quoted_string, :quoted_string]),
                                                               text(["abc", "def", "1231"])]
   end
 
   test "embedded newlines are lexed" do
-    assert matches Lexer.tokenize("123\n456\n\nabc"), [types([:integer, :integer, :name])]
+    assert matches Lexer.tokenize("123\n456\n\nabc"), [types([:integer, :integer, :string])]
   end
 
   test "unterminated string causes error" do

--- a/test/parser/parser_test.exs
+++ b/test/parser/parser_test.exs
@@ -5,9 +5,12 @@ defmodule Parser.ParserTest do
 
   use Parser.ParsingCase
 
-  defmacrop should_parse(text, expect \\ true) do
+  defmacrop should_parse(text, ast_text \\nil, expect \\ true) do
+    if ast_text == nil do
+      ast_text = text
+    end
     quote location: :keep do
-      assert matches(Parser.scan_and_parse(unquote(text)), ast_string(unquote(text))) == unquote(expect)
+      assert matches(Parser.scan_and_parse(unquote(text)), ast_string(unquote(ast_text))) == unquote(expect)
     end
   end
 
@@ -22,7 +25,7 @@ defmodule Parser.ParserTest do
   test "parsing options" do
     should_parse "foo --bar=1 -f"
     should_parse "$foo --bar=1 -f"
-    should_parse "ec2:list-vm --tags=\"a,b,c\" 10"
+    should_parse "ec2:list-vm --tags=\"a,b,c\" 10", "ec2:list-vm --tags=a,b,c 10"
   end
 
   test "parsing options referring to names" do
@@ -42,19 +45,19 @@ defmodule Parser.ParserTest do
   end
 
   test "parsing double quoted string arguments" do
-    should_parse "foo \"123 abc\""
+    should_parse "foo \"123 abc\"", "foo 123 abc"
   end
 
   test "parsing single quoted string arguments" do
-    should_parse "foo '123 abc'"
+    should_parse "foo '123 abc'", "foo 123 abc"
   end
 
   test "parsing escaped double quoted strings" do
-    should_parse "foo \"123\\\" abc\""
+    should_parse "foo \"123\\\"\" abc", "foo 123\" abc"
   end
 
   test "parsing escaped single quoted strings" do
-    should_parse "foo '123 a\\'b\\'c'"
+    should_parse "foo 123 a\\'b\\'c", "foo 123 a \\'b\\'c"
   end
 
   test "parsing :pipe pipelines" do

--- a/test/support/parsing_case.ex
+++ b/test/support/parsing_case.ex
@@ -41,7 +41,14 @@ defmodule Parser.ParsingCase do
   end
 
   def ast_string(ast_str) do
-    fn(ent) -> "#{ent}" == ast_str end
+    fn(ent) ->
+      if "#{ent}" != ast_str do
+        Logger.error("#{ent} didn't match expected #{ast_str}")
+        false
+      else
+        true
+      end
+    end
   end
 
   def matches({:ok, ents}, matchers) when is_list(matchers) do


### PR DESCRIPTION
This PR cleans up a bug introduced late last week around how Piper handles quoted strings. Specifically, last Thursday Piper begin emitting quoted strings with quotes after the strings were parsed. This caused problems for commands as they had no logic to strip quotes. Changes in the PR restores prior behavior of stripping quotes from quoted strings.

Also, this PR loosens parsing rules around command names. It removes `:name` as a lexer token type moving command name determination into the parser itself. Command names are now expected to be either a `string` token or a sequence of `string`, `colon`, `string` tokens. This should result in more intuitive parsing behavior.

Screenshot of Loop working with these changes:
![screen shot 2015-11-23 at 11 07 33 am](https://cloud.githubusercontent.com/assets/13558/11342018/26c7acbe-91d3-11e5-8524-61470f4215e6.png)
