### PR TITLE
Parse strings that start with numbers

### DIFF
--- a/lib/piper/command/lexer.ex
+++ b/lib/piper/command/lexer.ex
@@ -35,8 +35,8 @@ defmodule Piper.Command.Lexer do
   token :variable, pattern: ~r/\A(\$)([a-zA-Z0-9_\$])+/, post: :clean_variable
   # Boolean values
   token :bool, pattern: ~r/\A(true|TRUE|\#t|false|FALSE|\#f)/
-  token :float, pattern: ~r/\A([0-9])+\.([0-9])+/
-  token :integer, pattern: ~r/\A([0-9])+/
+  token :float, pattern: ~r/\A([0-9])+\.([0-9])+\b/
+  token :integer, pattern: ~r/\A([0-9])+\b/
   token :string, pattern: ~r/\A([a-zA-Z0-9_\-\/])+/
   token :string, pattern: ~r/\A([[:graph:]\/])+(?:\s|\z)*/, post: :clean_string
 

--- a/test/command/parser/lexer_test.exs
+++ b/test/command/parser/lexer_test.exs
@@ -1,5 +1,4 @@
-defmodule Parser.LexerTest do
-
+defmodule Parser.LexerTest do 
   use Parser.ParsingCase
 
   test "lexing whitespace returns empty token list" do
@@ -30,13 +29,14 @@ defmodule Parser.LexerTest do
     assert matches Lexer.tokenize("list_vms"), [types(:string), text("list_vms")]
   end
 
-  test "lexing invalid commands results in non-name results" do
-    assert matches Lexer.tokenize("1list_vms"), [types([:integer, :string]), text(["1", "list_vms"])]
-  end
-
   test "lexing numbers" do
     assert matches Lexer.tokenize("123 1072.05 0.05"), [types([:integer, :float, :float]),
                                                         text(["123", "1072.05", "0.05"])]
+  end
+
+  test "lexing strings that start with numbers" do
+    assert matches Lexer.tokenize("0fcaec64-0792-4826-8637-9a50593a7c03"), [types([:string]),
+                                                                            text(["0fcaec64-0792-4826-8637-9a50593a7c03"])]
   end
 
   test "lexing booleans" do


### PR DESCRIPTION
UUIDs, even if they start with numbers, are now parsed as strings.

Fixes https://github.com/operable/cog/issues/159
