### PR TITLE
Ambiguous alias errors

### DIFF
--- a/lib/piper/command/parser.ex
+++ b/lib/piper/command/parser.ex
@@ -23,10 +23,21 @@ defmodule Piper.Command.Parser do
       %SemanticError{}=error ->
         SemanticError.format_error(error)
       parser ->
-        {_parser, result} = pop_node(parser)
-        {:ok, result}
+        {parser, result} = pop_node(parser)
+        {:ok, prepare_result(result, opts)}
     end
   end
+
+  defp prepare_result(%Ast.Invocation{}=invocation, opts) do
+    case Keyword.get(opts, :return_pipeline, false) do
+      true ->
+        %Ast.Pipeline{invocations: [invocation]}
+      false ->
+        invocation
+    end
+  end
+  defp prepare_result(%Ast.Pipeline{}=pipeline, _),
+    do: pipeline
 
   defp parse_pipeline(parser, opts) do
     case pop_token(parser) do

--- a/lib/piper/command/semantic_error.ex
+++ b/lib/piper/command/semantic_error.ex
@@ -13,6 +13,10 @@ defmodule Piper.Command.SemanticError do
     error = new_with_position(near)
     %{error | reason: :ambiguous_command, meta: bundles}
   end
+  def new(near, {:ambiguous_alias, entities}) do
+    error = new_with_position(near)
+    %{error | reason: :ambiguous_alias, meta: entities}
+  end
 
   def update_position(error, %Token{line: line, col: col, text: text}) do
     %{error | line: line, col: col, text: text}
@@ -33,6 +37,10 @@ defmodule Piper.Command.SemanticError do
   defp message_for_reason(:ambiguous_command, text, bundles) do
     bundles = Enum.join(bundles, ", ")
     "Command name '#{text}' found in multiple bundles: #{bundles}."
+  end
+  defp message_for_reason(:ambiguous_alias, text, entities) do
+    {command_name, alias_name} = entities
+    "Ambiguous alias for '#{text}'. Command '#{command_name}' is ambiguous with alias '#{alias_name}'."
   end
 
   defp new_with_position(%Token{col: col, line: line, text: text}) do


### PR DESCRIPTION
When an alias is parsed that is ambiguous with a command we throw a semantic error reflecting that.