### PR TITLE
Adds parser support for Slack-style emoji references

### DIFF
--- a/lib/piper/command/ast/invocation.ex
+++ b/lib/piper/command/ast/invocation.ex
@@ -6,6 +6,10 @@ defmodule Piper.Command.Ast.Invocation do
   defstruct [line: nil, col: nil, command: nil, args: [], options: [],
              redirs: []]
 
+  def new(%Token{type: :ns_name}=token) do
+    %__MODULE__{line: token.line, col: token.col,
+                command: token.text}
+  end
   def new(%Token{type: :string}=token) do
     %__MODULE__{line: token.line, col: token.col,
                 command: token.text}
@@ -15,6 +19,25 @@ defmodule Piper.Command.Ast.Invocation do
   end
   def add_arg(%__MODULE__{args: args}=invocation, arg) do
     %{invocation | args: args ++ [arg]}
+  end
+
+  def bundle_name(%__MODULE__{command: command}) do
+    case String.split(command, "::") do
+      [bundle, _command] ->
+        bundle
+      [_] ->
+        hd(String.split(command, ":"))
+    end
+  end
+
+  def command_name(%__MODULE__{command: command}) do
+    case String.split(command, "::") do
+      [_bundle, command] ->
+        ":" <> command
+      [_] ->
+        [_bundle, command] = String.split(command, ":")
+        command
+    end
   end
 
   def add_redir(%__MODULE__{redirs: redirs}=invocation, dest) when is_binary(dest) do

--- a/lib/piper/command/lexer.ex
+++ b/lib/piper/command/lexer.ex
@@ -21,12 +21,14 @@ defmodule Piper.Command.Lexer do
   token :equals, pattern: ~r/\A=/
   token :lbracket, pattern: ~r/\A\[/
   token :rbracket, pattern: ~r/\A\]/
-  token :colon, pattern: ~r/\A\:/
+#  token :colon, pattern: ~r/\A\:/
   # Variable as option name
   token :option, pattern: ~r/\A\-\-/
   token :option, pattern: ~r/\A\-/
   # JSON literal
   token :json, pattern: ~r/\A{{([[:graph:]]| )+}}/, post: :clean_json
+  # Namespaced name
+  token :ns_name, pattern: ~r/\A[a-zA-Z]+[a-zA-Z0-9_\-]*::?[a-zA-Z]+[a-zA-Z0-9_\-:]*/
   # Tokenize quoted strings as whole strings
   token :quoted_string, pattern: ~r/\A'(\\\\A.|\\.|[^'])*'(?:\s|\z)*/, post: :clean_quoted_string
   # Tokenize double-quoted strings as whole strings

--- a/lib/piper/permissions/ast/literals.ex
+++ b/lib/piper/permissions/ast/literals.ex
@@ -8,6 +8,10 @@ defmodule Piper.Permissions.Ast.String do
     text = String.Chars.to_string(text)
     %__MODULE__{line: line, col: col, value: text}
   end
+  def new({:name, {line, col}, text}) do
+    text = String.Chars.to_string(text)
+    %__MODULE__{line: line, col: col, value: text}
+  end
   def new({:dqstring, {line, col}, text}) do
     text = String.Chars.to_string(text)
     %__MODULE__{line: line, col: col, value: text, quotes: "\""}

--- a/lib/piper/permissions/piper_rule_lexer.xrl
+++ b/lib/piper/permissions/piper_rule_lexer.xrl
@@ -7,6 +7,7 @@ INDEXED_ARG                     = arg\[([0-9])+\]
 OPTION                          = option
 AGGREGATE_OPTIONS               = options
 OPERATORS                       = (<|>|=<|>=|==|!=|and|or|not|in)
+NAME                            = [a-zA-Z]+[a-zA-Z0-9_\-]*::?[a-zA-Z]+[a-zA-Z0-9_\-:]*
 INTEGER                         = ([0-9])+
 FLOAT                           = ([0-9])+\.([0-9])+
 STRING                          = ([a-zA-Z0-9_\-])+
@@ -33,9 +34,10 @@ Rules.
 {RPAREN}                        : advance_count(length(TokenChars)), {token, {rparen, position(), ")"}}.
 {LBRACKET}                      : advance_count(length(TokenChars)), {token, {lbracket, position(), "["}}.
 {RBRACKET}                      : advance_count(length(TokenChars)), {token, {rbracket, position(), "]"}}.
-{COLON}                         : advance_count(length(TokenChars)), {token, {colon, position(), ":"}}.
+%%{COLON}                         : advance_count(length(TokenChars)), {token, {colon, position(), ":"}}.
 {COMMA}                         : advance_count(length(TokenChars)), {token, {comma, position(), ","}}.
 {REGEX}                         : advance_count(length(TokenChars)), {token, {regex, position(), build_regex(TokenChars)}}.
+{NAME}                          : advance_count(length(TokenChars)), {token, {name, position(), TokenChars}}.
 {FLOAT}                         : advance_count(length(TokenChars)), {token, {float, position(), list_to_float(TokenChars)}}.
 {INTEGER}                       : advance_count(length(TokenChars)), {token, {integer, position(), list_to_integer(TokenChars)}}.
 "(\\\^.|\\.|[^"])*"             : advance_count(length(TokenChars)), {token, {dqstring, position(), clean_string(TokenChars)}}.

--- a/lib/piper/permissions/piper_rule_parser.yrl
+++ b/lib/piper/permissions/piper_rule_parser.yrl
@@ -7,7 +7,7 @@ all any arg command have is must option when with
 and or in equiv not_equiv lt gt lte gte
 
 %% Data types
-boolean float integer dqstring sqstring string regex
+name boolean float integer dqstring sqstring string regex
 
 %% Punctuation
 colon comma lbracket rbracket lparen rparen.
@@ -18,7 +18,7 @@ access_rule
 
 command_selector command_criteria
 
-ns_name_list ns_name_list_body
+ns_name_list ns_name_list_body ns_name
 
 input_criterion input_criteria input_criteria_binop
 
@@ -68,11 +68,11 @@ permission_criteria ->
 permission_criteria ->
   all in ns_name_list : ?AST("PermissionExpr"):new('$1', track('$3')).
 permission_criteria ->
-  string_expr : verify_permission_name('$1'),
-                ?AST("PermissionExpr"):new(add_permission('$1')).
+  ns_name : verify_permission_name('$1'),
+           ?AST("PermissionExpr"):new(add_permission('$1')).
 
 command_criteria ->
-  is string_expr : ?AST("BinaryExpr"):new('$1', [{right, verify_command_name('$2')}]).
+  is ns_name : ?AST("BinaryExpr"):new('$1', [{right, verify_command_name('$2')}]).
 
 input_criterion ->
   input_criteria : '$1'.
@@ -132,13 +132,18 @@ ns_name_list ->
   lbracket ns_name_list_body rbracket : ?AST("List"):new('$1', '$2').
 
 ns_name_list_body ->
-  string_expr comma ns_name_list_body : [verify_permission_name('$1')] ++ '$3'.
+  ns_name comma ns_name_list_body : [verify_permission_name('$1')] ++ '$3'.
 ns_name_list_body ->
   regular_expr comma ns_name_list_body : ['$1'] ++ '$3'.
 ns_name_list_body ->
-  string_expr : [verify_permission_name('$1')].
+  ns_name : [verify_permission_name('$1')].
 ns_name_list_body ->
   regular_expr : ['$1'].
+
+ns_name ->
+  name : ?AST("String"):new('$1').
+ns_name ->
+  string_expr : '$1'.
 
 regular_expr ->
   regex : ?AST("Regex"):new('$1').
@@ -164,8 +169,6 @@ value ->
 value ->
   regular_expr : '$1'.
 
-string_expr ->
-  string colon string_expr : ?AST("String"):new(?AST("String"):new('$1'), '$2', '$3').
 string_expr ->
   dqstring colon string_expr : ?AST("String"):new(?AST("String"):new('$1', "\""), '$2', '$3').
 string_expr ->

--- a/test/command/parser/lexer_test.exs
+++ b/test/command/parser/lexer_test.exs
@@ -1,4 +1,4 @@
-defmodule Parser.LexerTest do 
+defmodule Parser.LexerTest do
   use Parser.ParsingCase
 
   test "lexing whitespace returns empty token list" do
@@ -81,8 +81,8 @@ defmodule Parser.LexerTest do
                                                          text(["--", "foo", "=", "foo@bar"])]
     assert matches Lexer.tokenize("--foo='foo bar'"), [types([:option, :string, :equals, :quoted_string]),
                                                        text(["--", "foo", "=", "foo bar"])]
-    assert matches Lexer.tokenize("--foo=test:test"), [types([:option, :string, :equals, :string, :colon, :string]),
-                                                       text(["--", "foo", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("--foo=test:test"), [types([:option, :string, :equals, :ns_name]),
+                                                       text(["--", "foo", "=", "test:test"])]
   end
 
   test "lexing long variable options" do
@@ -104,8 +104,8 @@ defmodule Parser.LexerTest do
                                                          text(["--", "foo", "=", "foo@bar"])]
     assert matches Lexer.tokenize("--$foo='foo bar'"), [types([:option, :variable, :equals, :quoted_string]),
                                                        text(["--", "foo", "=", "foo bar"])]
-    assert matches Lexer.tokenize("--$foo=test:test"), [types([:option, :variable, :equals, :string, :colon, :string]),
-                                                        text(["--", "foo", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("--$foo=test:test"), [types([:option, :variable, :equals, :ns_name]),
+                                                        text(["--", "foo", "=", "test:test"])]
   end
 
   test "lexing long variable optvars" do
@@ -127,8 +127,8 @@ defmodule Parser.LexerTest do
                                                       text(["-", "f", "foo@bar"])]
     assert matches Lexer.tokenize("-f 'foo bar'"), [types([:option, :string, :quoted_string]),
                                                        text(["-", "f", "foo bar"])]
-    assert matches Lexer.tokenize("-f test:test"), [types([:option, :string, :string, :colon, :string]),
-                                                    text(["-", "f", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-f test:test"), [types([:option, :string, :ns_name]),
+                                                    text(["-", "f", "test:test"])]
   end
 
   test "lexing short variable options" do
@@ -151,8 +151,8 @@ defmodule Parser.LexerTest do
                                                       text(["-", "f", "=", "foo@bar"])]
     assert matches Lexer.tokenize("-f='foo bar'"), [types([:option, :string, :equals, :quoted_string]),
                                                        text(["-", "f", "=", "foo bar"])]
-    assert matches Lexer.tokenize("-f=test:test"), [types([:option, :string, :equals, :string, :colon, :string]),
-                                                    text(["-", "f", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-f=test:test"), [types([:option, :string, :equals, :ns_name]),
+                                                    text(["-", "f", "=", "test:test"])]
   end
 
   test "lexing short options with assigned variable values" do
@@ -174,8 +174,8 @@ defmodule Parser.LexerTest do
                                                       text(["-", "f", "foo@bar"])]
     assert matches Lexer.tokenize("-$f 'foo bar'"), [types([:option, :variable, :quoted_string]),
                                                        text(["-", "f", "foo bar"])]
-    assert matches Lexer.tokenize("-$f test:test"), [types([:option, :variable, :string, :colon, :string]),
-                                                       text(["-", "f", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-$f test:test"), [types([:option, :variable, :ns_name]),
+                                                       text(["-", "f", "test:test"])]
   end
 
   test "lexing short variable optvars" do
@@ -197,8 +197,8 @@ defmodule Parser.LexerTest do
                                                       text(["-", "f", "=", "foo@bar"])]
     assert matches Lexer.tokenize("-$f='foo bar'"), [types([:option, :variable, :equals, :quoted_string]),
                                                        text(["-", "f", "=", "foo bar"])]
-    assert matches Lexer.tokenize("-$f=test:test"), [types([:option, :variable, :equals, :string, :colon, :string]),
-                                                       text(["-", "f", "=", "test", ":", "test"])]
+    assert matches Lexer.tokenize("-$f=test:test"), [types([:option, :variable, :equals, :ns_name]),
+                                                       text(["-", "f", "=", "test:test"])]
   end
 
   test "lexing short optvars with assigned variable value" do

--- a/test/permissions/lexer_test.exs
+++ b/test/permissions/lexer_test.exs
@@ -81,6 +81,8 @@ defmodule Piper.Permissions.LexerTest do
   test "quoting namespaced names" do
     matches "\"foo:bar\"", [dqstring: 'foo:bar']
     matches "'foo:bar'", [sqstring: 'foo:bar']
+    matches "\"foo:bar:\"", [dqstring: 'foo:bar:']
+    matches "'foo:bar:'", [sqstring: 'foo:bar:']
   end
 
   test "quoting quoted strings" do
@@ -108,7 +110,8 @@ defmodule Piper.Permissions.LexerTest do
   end
 
   test "tokenizing namespaced names" do
-    matches "foo:bar", [{:string, 'foo'}, :colon, {:string, 'bar'}]
+    matches "foo:bar", [name: 'foo:bar']
+    matches "foo:bar:", [name: 'foo:bar:']
   end
 
 end

--- a/test/permissions/parser_test.exs
+++ b/test/permissions/parser_test.exs
@@ -106,7 +106,7 @@ defmodule Piper.Permissions.ParserTest do
 
   test "random whitespacing parses" do
     matches_normalized "when#{ws}command#{ws}is#{ws} s3:bucket must#{ws} have#{ws}all in [s3:read]", ["s3:read"]
-    matches_normalized "when#{ws}command#{ws}is#{ws} s3:#{ws}bucket must#{ws} have#{ws}all in [s3#{ws}:read]", ["s3:read"]
+    matches_normalized "when#{ws}command#{ws}is#{ws} s3:bucket must#{ws} have#{ws}all in [s3:read]", ["s3:read"]
   end
 
   test "complicated rule round trips correctly" do

--- a/test/permissions/parser_test.exs
+++ b/test/permissions/parser_test.exs
@@ -104,6 +104,11 @@ defmodule Piper.Permissions.ParserTest do
       ["site:ops"], 2
   end
 
+  test "slack emoji commands successfully parse" do
+    matches "when command is pd::pager: must have site:ops", ["site:ops"], 0
+    matches "when command is pd::pager: with arg[0] == /prod.*/ must have site:ops and site:prod", ["site:ops", "site:prod"], 1
+  end
+
   test "random whitespacing parses" do
     matches_normalized "when#{ws}command#{ws}is#{ws} s3:bucket must#{ws} have#{ws}all in [s3:read]", ["s3:read"]
     matches_normalized "when#{ws}command#{ws}is#{ws} s3:bucket must#{ws} have#{ws}all in [s3:read]", ["s3:read"]


### PR DESCRIPTION
This PR teaches Piper's command and permission parsers how to parse Slack style `:boom:` emojis.