### PR TITLE
Return the full redirect, including URL prefix, if any

### DIFF
--- a/lib/piper/command/piper_cmd_parser.yrl
+++ b/lib/piper/command/piper_cmd_parser.yrl
@@ -211,7 +211,6 @@ token_to_string({Type, _, Text}) when Type == string orelse
   list_to_binary(Text).
 
 parse_redir_url({string, _, "chat"}, {datum, {Line, Col}, [$/, $/|Redirect]}) ->
-  ?AST("String"):new({datum, {Line, Col + 2}, Redirect});
+  ?AST("String"):new({datum, {Line, Col - 5}, "chat://" ++ Redirect});
 parse_redir_url({_, Line, _}, _) ->
   return_error(Line, "URL redirect targets must begin with chat://").
-

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -145,16 +145,16 @@ defmodule Parser.ParserTest do
     {:ok, ast} = Parser.scan_and_parse("foo | bar | baz > chat://#room1")
     assert ast.redirect_to != nil
     assert Enum.count(ast.redirect_to.targets) == 1
-    assert Ast.Pipeline.redirect_targets(ast) == ["#room1"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["#room1"]
+    assert Ast.Pipeline.redirect_targets(ast) == ["chat://#room1"]
+    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["chat://#room1"]
   end
 
   test "URL-style redirects and non-URL redirects are parsed" do
     {:ok, ast} = Parser.scan_and_parse("foo | bar | baz *> ops chat://#dev")
     assert ast.redirect_to != nil
     assert Enum.count(ast.redirect_to.targets) == 2
-    assert Ast.Pipeline.redirect_targets(ast) == ["ops", "#dev"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["ops", "#dev"]
+    assert Ast.Pipeline.redirect_targets(ast) == ["ops", "chat://#dev"]
+    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["ops", "chat://#dev"]
   end
 
   test "URL speling errors are caught :)" do


### PR DESCRIPTION
The executor needs the prefix in order to determine which adapter to use.