### PR TITLE
Error while parsing strings starting or ending with a colon

### DIFF
--- a/lib/piper/command/piper_cmd_lexer.xrl
+++ b/lib/piper/command/piper_cmd_lexer.xrl
@@ -9,6 +9,7 @@ RBRACKET                   = \]
 DOUBLE_DASH                = \-\-
 SINGLE_DASH                = \-
 COLON                      = :
+BAD_COLON                  = (:(\s)+)|((\s)+:)
 EQUALS                     = =
 DOT                        = \.
 SLACK_EMOJI                = :[a-zA-Z]+[a-zA-Z0-9_\-]*:
@@ -33,6 +34,7 @@ Rules.
 {REDIR_ONE}                : advance_count(length(TokenChars)), {token, {redir_one, position(), ">"}}.
 {LBRACKET}                 : advance_count(length(TokenChars)), {token, {lbracket, position(), "["}}.
 {RBRACKET}                 : advance_count(length(TokenChars)), {token, {rbracket, position(), "]"}}.
+{BAD_COLON}                : advance_count(length(TokenChars)), {token, {bad_colon, position(), ":"}}.
 {COLON}                    : advance_count(length(TokenChars)), {token, {colon, position(), ":"}}.
 {SLASH}                    : advance_count(length(TokenChars)), {token, {slash, position(), "/"}}.
 {EQUALS}                   : advance_count(length(TokenChars)), {token, {equals, position(), "="}}.
@@ -50,7 +52,7 @@ Rules.
 {DQUOTED_STRING}           : advance_count(length(TokenChars)), {token, {string, position(), clean_dquotes(TokenChars)}}.
 {SQUOTED_STRING}           : advance_count(length(TokenChars)), {token, {string, position(), clean_squotes(TokenChars)}}.
 {DATUM}                    : advance_count(length(TokenChars)), {token, {datum, position(), TokenChars}}.
-{WS}+                      : advance_count(length(TokenChars)), skip_token.
+{WS}                       : advance_count(length(TokenChars)), skip_token.
 {NEWLINE}+                 : advance_line(TokenLine), skip_token.
 
 Erlang code.

--- a/lib/piper/command/piper_cmd_lexer.xrl
+++ b/lib/piper/command/piper_cmd_lexer.xrl
@@ -9,7 +9,6 @@ RBRACKET                   = \]
 DOUBLE_DASH                = \-\-
 SINGLE_DASH                = \-
 COLON                      = :
-BAD_COLON                  = (:(\s)+)|((\s)+:)
 EQUALS                     = =
 DOT                        = \.
 SLACK_EMOJI                = :[a-zA-Z]+[a-zA-Z0-9_\-]*:
@@ -34,11 +33,13 @@ Rules.
 {REDIR_ONE}                : advance_count(length(TokenChars)), {token, {redir_one, position(), ">"}}.
 {LBRACKET}                 : advance_count(length(TokenChars)), {token, {lbracket, position(), "["}}.
 {RBRACKET}                 : advance_count(length(TokenChars)), {token, {rbracket, position(), "]"}}.
-{BAD_COLON}                : advance_count(length(TokenChars)), {token, {bad_colon, position(), ":"}}.
+{WS}{COLON}                : advance_count(length(TokenChars)), {token, {bad_colon, position(), ":"}}.
+{COLON}{WS}                : advance_count(length(TokenChars)), {token, {bad_colon, position(), ":"}}.
 {COLON}                    : advance_count(length(TokenChars)), {token, {colon, position(), ":"}}.
 {SLASH}                    : advance_count(length(TokenChars)), {token, {slash, position(), "/"}}.
 {EQUALS}                   : advance_count(length(TokenChars)), {token, {equals, position(), "="}}.
 {DOT}                      : advance_count(length(TokenChars)), {token, {dot, position(), "."}}.
+{WS}{SLACK_EMOJI}          : advance_count(length(TokenChars)), {token, {emoji, position(), tl(TokenChars)}}.
 {SLACK_EMOJI}              : advance_count(length(TokenChars)), {token, {emoji, position(), TokenChars}}.
 {HIPCHAT_EMOJI}            : advance_count(length(TokenChars)), {token, {emoji, position(), TokenChars}}.
 {VAR}                      : advance_count(length(TokenChars)), {token, {variable, position(), tl(TokenChars)}}.

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -275,4 +275,10 @@ defmodule Parser.ParserTest do
     should_not_parse "foo --opt1=$blah[3.wubba"
   end
 
+  test "malformed command names" do
+    should_not_parse ":foo bar"
+    should_not_parse "foo: bar"
+    should_not_parse "foo :bar"
+    should_not_parse "foo bar:"
+  end
 end


### PR DESCRIPTION
Here's an example:

```
{:ok, ast} = Piper.Command.Parser.scan_and_parse("foo: bar")
** (MatchError) no match of right hand side value: {:error, "Namespaced qualified names cannot contain spaces"}
```

Closes https://github.com/operable/cog/issues/314