### PR TITLE
add allow keyword to permissions parser

### DIFF
--- a/lib/piper/permissions/ast/chars/conditional_expr.ex
+++ b/lib/piper/permissions/ast/chars/conditional_expr.ex
@@ -2,6 +2,9 @@ defimpl String.Chars, for: Piper.Permissions.Ast.ConditionalExpr do
 
   alias Piper.Permissions.Ast
 
+  def to_string(%Ast.ConditionalExpr{op: :allow}) do
+    "allow"
+  end
   def to_string(%Ast.ConditionalExpr{parens: parens, left: lhs, right: rhs, op: op}) do
     text = "#{lhs} #{op} #{rhs}"
     if parens == true do

--- a/lib/piper/permissions/ast/chars/rule.ex
+++ b/lib/piper/permissions/ast/chars/rule.ex
@@ -3,7 +3,12 @@ defimpl String.Chars, for: Piper.Permissions.Ast.Rule do
   alias Piper.Permissions.Ast
 
   def to_string(%Ast.Rule{command_selector: cs, permission_selector: ps}) do
-    "when #{cs} must have #{ps}"
+    "when #{cs} #{ps_str(ps)}"
   end
+
+  defp ps_str(%Ast.ConditionalExpr{op: :allow}=ps),
+    do: "#{ps}"
+  defp ps_str(ps),
+    do: "must have #{ps}"
 
 end

--- a/lib/piper/permissions/ast/conditional_expr.ex
+++ b/lib/piper/permissions/ast/conditional_expr.ex
@@ -5,12 +5,16 @@ defmodule Piper.Permissions.Ast.ConditionalExpr do
   defstruct ['$ast$': "cond_expr", line: nil, col: nil, op: nil, left: nil, right: nil,
              parens: false]
 
-  def new({type, {line, col}, _}, opts \\ []) when type in [:and, :or] do
+  def new({type, {line, col}, _}, opts) when type in [:and, :or] do
     lhs = Keyword.get(opts, :left)
     rhs = Keyword.get(opts, :right)
     parens = Keyword.get(opts, :parens, false)
     %__MODULE__{line: line, col: col, op: type, left: lhs,
                 right: rhs, parens: parens}
+  end
+
+  def new({:allow, {line, col}, _}) do
+    %__MODULE__{line: line, col: col, op: :allow}
   end
 
   def update(expr, opts \\ []) do

--- a/lib/piper/permissions/ast/json/binary_expr.ex
+++ b/lib/piper/permissions/ast/json/binary_expr.ex
@@ -5,6 +5,11 @@ defimpl Piper.Permissions.Json, for: [Piper.Permissions.Ast.BinaryExpr,
 
   def from_json!(svalue, %{"line" => line,
                            "col" => col,
+                           "op" => "allow"}) do
+    %{svalue | line: line, col: col, op: :allow}
+  end
+  def from_json!(svalue, %{"line" => line,
+                           "col" => col,
                            "left" => left,
                            "right" => right,
                            "parens" => parens,

--- a/lib/piper/permissions/piper_rule_lexer.xrl
+++ b/lib/piper/permissions/piper_rule_lexer.xrl
@@ -1,6 +1,6 @@
 Definitions.
 
-RESERVED                        = (when|with|must|have|command|true|false|any|all|is)
+RESERVED                        = (when|with|must|have|command|true|false|any|all|is|allow)
 BARE_ARG                        = arg
 AGGREGATE_ARGS                  = args
 INDEXED_ARG                     = arg\[([0-9])+\]

--- a/lib/piper/permissions/piper_rule_parser.yrl
+++ b/lib/piper/permissions/piper_rule_parser.yrl
@@ -1,7 +1,7 @@
 Terminals
 
 %% Keywords
-all any arg command have is must option when with
+all any arg command have is must option when with allow
 
 %% Operators
 and or in equiv not_equiv lt gt lte gte
@@ -41,6 +41,8 @@ command_selector ->
   when command command_criteria with input_criterion : Lhs = update('$3', [{left, ?AST("Var"):new(<<"command">>)}]),
                                                        ?AST("BinaryExpr"):new('$4', [{left, Lhs},
                                                                                      {right, '$5'}]).
+permission_selector ->
+  allow : ?AST("ConditionalExpr"):new('$1').
 permission_selector ->
   must have permission_criterion : '$3'.
 
@@ -235,7 +237,7 @@ verify_permission_name(String) ->
     true ->
       String;
     false ->
-      return_error(get_location(String), "References to permissions must start with a command bundle name or \"site\"")
+      return_error(get_location(String), "References to permissions must be the literal \"allow\" or start with a command bundle name or \"site\"")
   end.
 
 verify_name(String) ->

--- a/test/permissions/parser_test.exs
+++ b/test/permissions/parser_test.exs
@@ -138,9 +138,20 @@ defmodule Piper.Permissions.ParserTest do
   test "parser and lexer error handling" do
     {:error, "illegal characters \"!r\"."} = Parser.parse("when command is foo:bar mst have foo!read")
     {:error, "(Line: 1, Col: 5) syntax error before: \"comand\"."} = Parser.parse("when comand is foo:bar but have foo:read")
+    {:error, "(Line: 1, Col: 24) syntax error before: \"foo\"."} = Parser.parse("when command is foo:bar foo:read")
     {:error,
-     "(Line: 1, Col: 34) References to permissions must start with a command bundle name or \"site\"."} =
+     "(Line: 1, Col: 34) References to permissions must be the literal \"allow\" or start with a command bundle name or \"site\"."} =
       Parser.parse("when command is foo:bar must have foo")
+  end
+
+  test "rules allow the keyword 'allow' in permission expressions" do
+    matches "when command is s3:bucket allow", []
+  end
+
+  test "when 'allow' is used it must be the only phrase in the permission expression" do
+    {:error, "(Line: 1, Col: 34) syntax error before: \"allow\"."} = Parser.parse("when command is foo:bar must have allow")
+    {:error, "(Line: 1, Col: 46) syntax error before: \"allow\"."} = Parser.parse("when command is foo:bar must have foo:read or allow")
+    {:error, "(Line: 1, Col: 30) syntax error before: \"and\"."} = Parser.parse("when command is foo:bar allow and allow")
   end
 
 end


### PR DESCRIPTION
This updates piper to accept "allow" as a valid permission expression.

`"when command is bundle:command allow"`