### PR TITLE
Added Permissions.Ast.Rule.permissions_used/1

### DIFF
--- a/lib/piper/permissions/ast/rule.ex
+++ b/lib/piper/permissions/ast/rule.ex
@@ -31,4 +31,30 @@ defmodule Piper.Permissions.Ast.Rule do
   end
   def find_command_name(_), do: nil
 
+  def permissions_used(rule = %__MODULE__{}) do
+    Enum.sort(permissions_used(rule.permission_selector, []))
+  end
+
+  def permissions_used(nil, accum) do
+    accum
+  end
+  def permissions_used(%Ast.PermissionExpr{perms: %Ast.List{values: values}}, accum) do
+    Enum.reduce(values, accum, fn(v, acc) ->
+      if Enum.member?(acc, v.value) do
+        accum
+      else
+        [v.value|acc]
+      end end)
+  end
+  def permissions_used(%Ast.PermissionExpr{perms: %Ast.String{value: name}}, accum) do
+    if Enum.member?(accum, name) do
+      accum
+    else
+      [name|accum]
+    end
+  end
+  def permissions_used(expr, accum) do
+    accum = permissions_used(Map.get(expr, :left), accum)
+    permissions_used(Map.get(expr, :right), accum)
+  end
 end

--- a/lib/piper/permissions/ast/rule.ex
+++ b/lib/piper/permissions/ast/rule.ex
@@ -32,29 +32,21 @@ defmodule Piper.Permissions.Ast.Rule do
   def find_command_name(_), do: nil
 
   def permissions_used(rule = %__MODULE__{}) do
-    Enum.sort(permissions_used(rule.permission_selector, []))
+    permissions_used(rule.permission_selector, []) |> Enum.uniq |> Enum.sort
   end
 
-  def permissions_used(nil, accum) do
-    accum
-  end
   def permissions_used(%Ast.PermissionExpr{perms: %Ast.List{values: values}}, accum) do
-    Enum.reduce(values, accum, fn(v, acc) ->
-      if Enum.member?(acc, v.value) do
-        accum
-      else
-        [v.value|acc]
-      end end)
+    Enum.reduce(values, accum, &([&1.value|&2]))
   end
   def permissions_used(%Ast.PermissionExpr{perms: %Ast.String{value: name}}, accum) do
-    if Enum.member?(accum, name) do
-      accum
-    else
-      [name|accum]
-    end
+    [name|accum]
   end
-  def permissions_used(expr, accum) do
-    accum = permissions_used(Map.get(expr, :left), accum)
-    permissions_used(Map.get(expr, :right), accum)
+  def permissions_used(%{left: left, right: right}, accum) do
+    accum = permissions_used(left, accum)
+    permissions_used(right, accum)
   end
+  def permissions_used(_, accum) do
+    accum
+  end
+
 end

--- a/test/permissions/parser_test.exs
+++ b/test/permissions/parser_test.exs
@@ -14,6 +14,7 @@ defmodule Piper.Permissions.ParserTest do
     assert "#{ast}" == text
     assert "#{json_ast}" == text
     assert Enum.sort(perms) == parsed_perms
+    assert Enum.sort(perms) == Rule.permissions_used(json_ast)
   end
 
   defp matches_normalized(text, perms, score \\ 0) do


### PR DESCRIPTION
This new function allows callers to query a rule for the complete list
of referenced permissions. This information is already available at
parse time but not when Cog needs to generate sane error messages.

This is 50% of a fix for [#758](https://github.com/operable/cog/issues/758).