### PR TITLE
Detect and raise when non-scalar values are bound

### DIFF
--- a/lib/piper/command/ast/bad_value_error.ex
+++ b/lib/piper/command/ast/bad_value_error.ex
@@ -1,0 +1,9 @@
+defmodule Piper.Command.Ast.BadValueError do
+
+  defexception [:name, :value]
+
+  def message(%__MODULE__{name: name, value: value}) do
+    "#{inspect value, pretty: true} bound to #{name} instead of expected scalar."
+  end
+
+end

--- a/lib/piper/command/ast/chars/variable_chars.ex
+++ b/lib/piper/command/ast/chars/variable_chars.ex
@@ -1,5 +1,6 @@
 defimpl String.Chars, for: Piper.Command.Ast.Variable do
 
+  alias Piper.Command.Ast.BadValueError
   alias Piper.Command.Ast.Variable
 
   def to_string(%Variable{name: name, value: nil, ops: ops}) do
@@ -9,6 +10,9 @@ defimpl String.Chars, for: Piper.Command.Ast.Variable do
     else
       text <> ops_to_text(ops)
     end
+  end
+  def to_string(%Variable{name: name, value: value}) when is_map(value) or is_list(value) do
+    raise BadValueError, name: "$#{name}", value: value
   end
   def to_string(%Variable{value: value}) do
     "#{value}"

--- a/test/command/exec/bind_test.exs
+++ b/test/command/exec/bind_test.exs
@@ -7,6 +7,7 @@ defmodule Bind.BindTest do
   alias Piper.Command.Bind.Scope
   alias Piper.Command.Bind
   alias Piper.Command.Ast, as: Ast
+  alias Piper.Command.Ast.BadValueError
 
   defp link_scopes([]) do
     Bind.Scope.empty_scope()
@@ -92,6 +93,12 @@ defmodule Bind.BindTest do
   end
 
   # go up the chain, too
+
+  test "binding a map to a variable fails" do
+    scope = Bind.Scope.from_map(%{"foo" => %{"bar" => 123}})
+    {:ok, ast} = parse_and_bind2("my:cmd --test=$foo", scope)
+    assert_raise BadValueError, fn() -> "#{ast}" end
+  end
 
   test "array indexing" do
     scope = Bind.Scope.from_map(%{"region" => ["us-west-1", "us-east-1"]})


### PR DESCRIPTION
1/2 of a fix for https://github.com/operable/cog/issues/916