### PR TITLE
allow datum.(datum|string)

### DIFF
--- a/src/piper_cmd_parser.yrl
+++ b/src/piper_cmd_parser.yrl
@@ -87,6 +87,10 @@ arg ->
 arg ->
   string ns_separator emoji : merge_strings(['$1', '$2', '$3']).
 arg ->
+  datum dot datum : merge_strings(['$1', '$2', '$3']).
+arg ->
+  datum dot string : merge_strings(['$1', '$2', '$3']).
+arg ->
   any : '$1'.
 
 short_option ->

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -84,6 +84,7 @@ defmodule Parser.ParserTest do
   test "parsing args" do
     should_parse "wubba:foo 123 abc", nil, 1
     should_parse "foo 123 abc", "foo 123 abc", 1
+    should_parse "foo bar/baz.quux", "foo bar/baz.quux", 1
   end
 
   test "parsing double quoted string arguments" do


### PR DESCRIPTION
This allows "echo path/to/file.ext" to parse.