### PR TITLE
Reworked command parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ erl_crash.dump
 *.ez
 lib/piper/command/*.erl
 lib/piper/permissions/*.erl
-src/*.erl
+src/piper*lexer.erl
+src/piper*parser.erl

--- a/lib/piper/command/ast/bind/interpolated_string.ex
+++ b/lib/piper/command/ast/bind/interpolated_string.ex
@@ -1,0 +1,37 @@
+defimpl Piper.Common.Bindable, for: Piper.Command.Ast.InterpolatedString do
+
+  alias Piper.Common.Bindable
+  alias Piper.Command.Ast.InterpolatedString
+
+  def resolve(%InterpolatedString{}=interp, scope) do
+    Enum.reduce_while(interp.exprs, {:ok, scope}, &resolve_exprs/2)
+  end
+
+  def bind(%InterpolatedString{}=interp, scope) do
+    case Enum.reduce_while(interp.exprs, {:ok, scope, []}, &bind_exprs/2) do
+      {:ok, scope, exprs} ->
+        {:ok, %{interp | exprs: Enum.reverse(exprs), bound: true}, scope}
+      error ->
+        error
+    end
+  end
+
+  defp resolve_exprs(expr, {:ok, scope}) do
+    case Bindable.resolve(expr, scope) do
+      {:ok, scope} ->
+        {:cont, {:ok, scope}}
+      error ->
+        {:halt, error}
+    end
+  end
+
+  defp bind_exprs(expr, {:ok, scope, accum}) do
+    case Bindable.bind(expr, scope) do
+      {:ok, expr, scope} ->
+        {:cont, {:ok, scope, [expr|accum]}}
+      error ->
+        {:halt, error}
+    end
+  end
+
+end

--- a/lib/piper/command/ast/chars/interpolated_string_chars.ex
+++ b/lib/piper/command/ast/chars/interpolated_string_chars.ex
@@ -1,0 +1,25 @@
+defimpl String.Chars, for: Piper.Command.Ast.InterpolatedString do
+
+  alias Piper.Command.Ast.Variable
+  alias Piper.Command.Ast.InterpolatedString
+
+  def to_string(%InterpolatedString{exprs: exprs, quote_type: quote_type, bound: false}) do
+    text = exprs
+           |> Enum.map(&(convert_element(&1)))
+           |> Enum.join
+    wrap_quotes(text, quote_type)
+  end
+  def to_string(%InterpolatedString{bound: true, exprs: exprs}) do
+    Enum.map_join(exprs, &("#{&1}"))
+  end
+
+  defp convert_element(%Variable{}=element) do
+    Variable.as_interpolated(element)
+  end
+  defp convert_element(element), do: "#{element}"
+
+  defp wrap_quotes(text, nil), do: text
+  defp wrap_quotes(text, :squote), do: "'#{text}'"
+  defp wrap_quotes(text, :dquote), do: "\"#{text}\""
+
+end

--- a/lib/piper/command/ast/chars/literals_chars.ex
+++ b/lib/piper/command/ast/chars/literals_chars.ex
@@ -10,8 +10,16 @@ end
 
 defimpl String.Chars, for: [Piper.Command.Ast.String] do
 
-  def to_string(str) do
-    str.value
+  alias Piper.Command.Ast
+
+  def to_string(%Ast.String{quote_type: :squote, value: value}) do
+    "'#{value}'"
+  end
+  def to_string(%Ast.String{quote_type: :dquote, value: value}) do
+    "\"#{value}\""
+  end
+  def to_string(%Ast.String{quote_type: nil, value: value}) do
+    value
   end
 
 end

--- a/lib/piper/command/ast/chars/variable_chars.ex
+++ b/lib/piper/command/ast/chars/variable_chars.ex
@@ -2,13 +2,14 @@ defimpl String.Chars, for: Piper.Command.Ast.Variable do
 
   alias Piper.Command.Ast.Variable
 
-  def to_string(%Variable{name: name, value: nil, ops: ops}) do
-    text = "$#{name}"
-    if Enum.empty?(ops) do
+  def to_string(%Variable{value: nil, ops: ops}=var) do
+    text = prefix(var)
+    updated = if Enum.empty?(ops) do
       text
     else
       text <> ops_to_text(ops)
     end
+    suffix(var, updated)
   end
   def to_string(%Variable{value: value}) when is_map(value) or is_list(value) do
     Poison.encode!(value)
@@ -27,5 +28,12 @@ defimpl String.Chars, for: Piper.Command.Ast.Variable do
   defp op_to_text({:key, key}, acc) do
     acc <> ".#{key}"
   end
+
+  defp prefix(%Variable{name: name, prefix: prefix}) do
+    "#{prefix}#{name}"
+  end
+
+  defp suffix(%Variable{suffix: nil}, text), do: text
+  defp suffix(%Variable{suffix: suffix}, text), do: "#{text}#{suffix}"
 
 end

--- a/lib/piper/command/ast/interpolated_string.ex
+++ b/lib/piper/command/ast/interpolated_string.ex
@@ -1,0 +1,12 @@
+defmodule Piper.Command.Ast.InterpolatedString do
+
+  alias Piper.Command.Ast
+
+  defstruct [:exprs, :bound, :quote_type]
+
+  def new([%Ast.String{}=str]), do: str
+  def new(exprs) when is_list(exprs) do
+    %__MODULE__{exprs: exprs, bound: false}
+  end
+
+end

--- a/lib/piper/command/ast/literals.ex
+++ b/lib/piper/command/ast/literals.ex
@@ -50,7 +50,7 @@ end
 
 defmodule Piper.Command.Ast.String do
 
-  defstruct [line: nil, col: nil, value: nil]
+  defstruct [line: nil, col: nil, value: nil, quote_type: nil]
 
   def new({:string, {line, col}, value}) do
     %__MODULE__{line: line, col: col, value: String.Chars.to_string(value)}
@@ -65,6 +65,9 @@ defmodule Piper.Command.Ast.String do
     %__MODULE__{line: 0, col: 0, value: value}
   end
 
+  def new({:string, {line, col}, value}, quote_type) when quote_type in [:squote, :dquote] do
+    %__MODULE__{line: line, col: col, value: String.Chars.to_string(value), quote_type: quote_type}
+  end
   def new({line, col}, value) do
     %__MODULE__{line: line, col: col, value: value}
   end

--- a/lib/piper/command/ast/variable.ex
+++ b/lib/piper/command/ast/variable.ex
@@ -1,15 +1,20 @@
 defmodule Piper.Command.Ast.Variable do
 
-  defstruct [:line, :col, :name, :value, :ops]
+  defstruct [:line, :col, :name, :value, :ops, :prefix, :suffix]
 
   def new(var_info, ops \\ [])
 
   def new({:variable, {line, col}, name}, ops) do
-    %__MODULE__{line: line, col: col, name: name, ops: ops}
+    %__MODULE__{line: line, col: col, name: name, ops: ops, prefix: "$"}
   end
 
   def new(name, ops) when is_binary(name) do
-    %__MODULE__{line: 0, col: 0, name: name, ops: ops}
+    %__MODULE__{line: 0, col: 0, name: name, ops: ops, prefix: "$"}
+  end
+
+  def as_interpolated(%__MODULE__{}=var) do
+    var = %{var | prefix: "${", suffix: "}"}
+    "#{var}"
   end
 
 end

--- a/lib/piper/command/semantic_error.ex
+++ b/lib/piper/command/semantic_error.ex
@@ -29,6 +29,11 @@ defmodule Piper.Command.SemanticError do
     %{error | reason: :alias_cycle, meta: cycle}
   end
 
+  def new({:syntax, message}) do
+    error = init(message)
+    %{error | reason: :syntax}
+  end
+
   def format_error(%__MODULE__{text: text, reason: reason, meta: meta}) do
     {:error, message_for_reason(reason, text, meta)}
   end
@@ -51,6 +56,9 @@ defmodule Piper.Command.SemanticError do
   end
   defp message_for_reason(:alias_cycle, _text, [first, last]) do
     "Infinite alias expansion loop detected '#{first}' -> '#{last}'."
+  end
+  defp message_for_reason(:syntax, text, _) do
+    text
   end
 
   defp init({_, _, text}) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,9 @@ defmodule Piper.Mixfile do
     [app: :piper,
      version: "0.16.0",
      elixir: "~> 1.3.1",
-     erlc_options: [:debug_info, :warnings_as_errors],
-     leex_options: [:warnings_as_errors],
+     erlc_options: [:debug_info] ++ warnings_as_errors(:erl),
+     leex_options: warnings_as_errors(:erl),
+     elixirc_options: warnings_as_errors(:ex),
      elixirc_paths: elixirc_paths(Mix.env),
      start_permanent: Mix.env == :prod,
      deps: deps] ++ compile_protocols(Mix.env)
@@ -26,5 +27,24 @@ defmodule Piper.Mixfile do
 
   defp compile_protocols(:prod), do: [build_embedded: true]
   defp compile_protocols(_), do: []
+
+  defp warnings_as_errors(type) do
+    case System.get_env("ALLOW_WARNINGS") do
+      nil ->
+        case type do
+          :ex ->
+            [{:warnings_as_errors, true}]
+          :erl ->
+            [:warnings_as_errors]
+        end
+      _ ->
+        case type do
+          :ex ->
+            [{:warnings_as_errors, false}]
+          :erl ->
+            []
+        end
+    end
+  end
 
 end

--- a/src/piper_cmd2_arg_lexer.xrl
+++ b/src/piper_cmd2_arg_lexer.xrl
@@ -1,0 +1,28 @@
+Definitions.
+
+EQ                     = =
+INTEGER                = (\-)?[0-9]+
+FLOAT                  = (\-)?[0-9]+\.[0-9]+
+BOOL                   = true|false
+SHORT_OPTION           = \-[a-zA-Z0-9]
+LONG_OPTION            = \-\-[a-zA-Z0-9_\-]+
+TEXT                   = ([^\-=]).*
+DQUOTED_TEXT           = "(\\\^.|\\.|[^"])*"
+SQUOTED_TEXT           = '(\\\^.|\\.|[^'])*'
+
+
+Rules.
+
+{EQ}                   : {token, {equals, ?advance_count(TokenChars), "="}}.
+{INTEGER}              : {token, {integer, ?advance_count(TokenChars), TokenChars}}.
+{FLOAT}                : {token, {float, ?advance_count(TokenChars), TokenChars}}.
+{BOOL}                 : {token, {bool, ?advance_count(TokenChars), TokenChars}}.
+{SHORT_OPTION}         : {token, {short_option, ?advance_count(TokenChars), TokenChars}}.
+{LONG_OPTION}          : {token, {long_option, ?advance_count(TokenChars), TokenChars}}.
+{DQUOTED_TEXT}         : {token, {dquoted_text, ?advance_count(TokenChars), TokenChars}}.
+{SQUOTED_TEXT}         : {token, {squoted_text, ?advance_count(TokenChars), TokenChars}}.
+{TEXT}                 : {token, {text, ?advance_count(TokenChars), TokenChars}}.
+
+Erlang code.
+
+-include("piper_cmd2_lexer.hrl").

--- a/src/piper_cmd2_arg_parser.yrl
+++ b/src/piper_cmd2_arg_parser.yrl
@@ -1,0 +1,65 @@
+Terminals
+
+%% Types
+integer float bool short_option long_option text
+
+%% Notation
+equals.
+
+Nonterminals
+
+arg value.
+
+Rootsymbol arg.
+
+arg ->
+  short_option equals value : ?new_ast(option, [[{name, option_name('$1')},
+                                                {value, '$3'},
+                                                {type, short}]]).
+arg ->
+  short_option equals : ?new_ast(option, [[{name, option_name('$1')},
+                                           {value, next_arg},
+                                           {type, short}]]).
+arg ->
+  short_option : ?new_ast(option, [[{name, option_name('$1')},
+                                    {type, short}]]).
+arg ->
+  long_option equals value : ?new_ast(option, [[{name, option_name('$1')},
+                                                {value, '$3'},
+                                                {type, long}]]).
+arg ->
+  long_option equals : ?new_ast(option, [[{name, option_name('$1')},
+                                          {value, next_arg},
+                                          {type, long}]]).
+arg ->
+  long_option : ?new_ast(option, [[{name, option_name('$1')},
+                                   {type, long}]]).
+arg ->
+  value : '$1'.
+
+value ->
+  integer : ?new_ast(integer, ['$1']).
+value ->
+  float : ?new_ast(float, ['$1']).
+value ->
+  bool : ?new_ast(bool, ['$1']).
+value ->
+  text : case piper_cmd2_var_lexer:possible_varexpr('$1') of
+           true ->
+             ?parse_token('$1', var, fun(V) -> V end);
+           false ->
+             ?new_ast(string, [text_to_string('$1')])
+         end.
+
+Erlang code.
+
+-include("piper_cmd2_parser.hrl").
+
+text_to_string({text, Position, Value}) ->
+  {string, Position, Value}.
+
+option_name({Type, {LineNum, Col}, Name}) when Type == long_option;
+                                               Type == short_option ->
+  Name1 = re:replace(Name, "^(\-\-|\-)", "", [{return, list}]),
+  Col1 = Col + (length(Name) - length(Name1)),
+  ?new_ast(string, [{string, {LineNum, Col1}, Name1}]).

--- a/src/piper_cmd2_interp_lexer.xrl
+++ b/src/piper_cmd2_interp_lexer.xrl
@@ -1,0 +1,15 @@
+Definitions.
+
+INTERP_VALUE                    = \${([^\${}]|\\\$|\\{|\\})+}
+TEXT                            = (\\\^.|\\.|[^\$])+
+Rules.
+
+{INTERP_VALUE}                  : {token, {interp_value, ?advance_count(TokenChars), expr_text(TokenChars)}}.
+{TEXT}                          : {token, {text, ?advance_count(TokenChars), TokenChars}}.
+
+Erlang code.
+
+-include("piper_cmd2_lexer.hrl").
+
+expr_text(Text) ->
+  [$$|re:replace(Text, "(^\\${|}$)", "", [{return, list}, global])].

--- a/src/piper_cmd2_interp_parser.yrl
+++ b/src/piper_cmd2_interp_parser.yrl
@@ -1,0 +1,28 @@
+Terminals
+
+interp_value text.
+
+Nonterminals
+
+interpexpr parts.
+
+Rootsymbol interpexpr.
+
+interpexpr ->
+  parts : ?new_ast(interp_string, ['$1']).
+
+parts ->
+  text : [?new_ast(string, [text_to_string('$1')])].
+parts ->
+  interp_value : [?parse_token('$1', var, fun(V) -> V end)].
+parts ->
+  text parts : [?new_ast(string, [text_to_string('$1')])] ++ '$2'.
+parts ->
+  interp_value parts : [?parse_token('$1', var, fun(V) -> V end)] ++ '$2'.
+
+Erlang code.
+
+-include("piper_cmd2_parser.hrl").
+
+text_to_string({text, Position, Value}) ->
+  {string, Position, Value}.

--- a/src/piper_cmd2_lexer.hrl
+++ b/src/piper_cmd2_lexer.hrl
@@ -1,0 +1,3 @@
+-define(lexer_util, piper_cmd2_lexer_util).
+-define(advance_count(C), ?lexer_util:advance_count(length(C))).
+-define(advance_line(L), ?lexer_util:advance_line(L)).

--- a/src/piper_cmd2_lexer.xrl
+++ b/src/piper_cmd2_lexer.xrl
@@ -1,0 +1,78 @@
+Definitions.
+
+PIPE                       = \|
+IFF                        = &&
+REDIR_MULTI                = \*>
+REDIR_ONE                  = >
+TEXT                       = ([^\"'\s])+
+DQUOTED_TEXT               = "(\\\^.|\\.|[^"])*"
+BAD_DQUOTED_TEXT           = "(\\\^.|\\.|[^"])*
+SQUOTED_TEXT               = '(\\\^.|\\.|[^'])*'
+BAD_SQUOTED_TEXT           = '(\\\^.|\\.|[^'])*
+WS                         = \s
+NEWLINE                    = (\n|\r\n)
+
+Rules.
+
+{PIPE}                     : {token, {pipe, ?advance_count(TokenChars), "|"}}.
+{IFF}                      : {token, {iff, ?advance_count(TokenChars), "&&"}}.
+{REDIR_MULTI}              : {token, {redir_multi, ?advance_count(TokenChars), "*>"}}.
+{REDIR_ONE}                : {token, {redir_one, ?advance_count(TokenChars), ">"}}.
+{DQUOTED_TEXT}             : {token, {dquoted_text, ?advance_count(TokenChars), TokenChars}}.
+{BAD_DQUOTED_TEXT}         : {error, ["Missing double quote: ", TokenChars]}.
+{SQUOTED_TEXT}             : {token, {squoted_text, ?advance_count(TokenChars), TokenChars}}.
+{BAD_SQUOTED_TEXT}         : {error, ["Missing single quote: ", TokenChars]}.
+{TEXT}                     : {token, {text, ?advance_count(TokenChars), TokenChars}}.
+{WS}                       : ?advance_count(TokenChars), skip_token.
+{NEWLINE}                  : ?advance_line(TokenLine), skip_token.
+
+Erlang code.
+
+-include("piper_cmd2_lexer.hrl").
+
+-export([scan/1,
+         apply_fixups/1]).
+
+scan(String) ->
+  case string(String) of
+    {ok, Tokens, N} ->
+      {ok, apply_fixups(Tokens), N};
+    Error ->
+      Error
+  end.
+
+apply_fixups(Tokens) -> apply_fixups(Tokens, []).
+
+apply_fixups([], Accum) -> lists:reverse(Accum);
+apply_fixups([{text, T1Pos, T1Text}=T1, {Quoted, _, QuotedValue}=QT, {text, _, T2Text}=T2|T], Accum) when Quoted == squoted_text;
+                                                                                                          Quoted == dquoted_text ->
+  case re:run(T1Text, "\\[$", [{capture, none}]) of
+    match ->
+      case re:run(T2Text, "^\\]", [{capture, none}]) of
+        match ->
+          Updated = {text, T1Pos, T1Text ++ QuotedValue ++ T2Text},
+          apply_fixups([Updated|T], Accum);
+        nomatch ->
+          apply_fixups([QT, T2|T], [T1|Accum])
+      end;
+    nomatch ->
+      case re:run(T1Text, "\\.$", [{capture, none}]) of
+        match ->
+          Updated = {text, T1Pos, T1Text ++ QuotedValue},
+          apply_fixups([Updated, T2|T], Accum);
+        nomatch ->
+          apply_fixups([QT, T2|T], [T1|Accum])
+      end
+  end;
+apply_fixups([{text, T1Pos, T1Text}=T1, {TextType, _, T2Text}=T2|T], Accum) when TextType == text;
+                                                                                 TextType == squoted_text;
+                                                                                 TextType == dquoted_text ->
+  case re:run(T2Text, "(^\\.|^\\[)", [{capture, none}]) of
+    match ->
+      Updated = {text, T1Pos, T1Text ++ T2Text},
+      apply_fixups([Updated|T], Accum);
+    nomatch ->
+      apply_fixups([T2|T], [T1|Accum])
+  end;
+apply_fixups([H|T], Accum) ->
+  apply_fixups(T, [H|Accum]).

--- a/src/piper_cmd2_lexer_util.erl
+++ b/src/piper_cmd2_lexer_util.erl
@@ -1,0 +1,23 @@
+-module(piper_cmd2_lexer_util).
+
+-export([dummy_context/0,
+         position/0,
+         advance_line/1,
+         advance_count/1]).
+
+dummy_context() ->
+  {ok, Pid} = 'Elixir.Piper.Command.ParseContext':start_link(2),
+  erlang:put(piper_cp_context, Pid).
+
+position() ->
+  Context = erlang:get(piper_cp_context),
+  'Elixir.Piper.Command.ParseContext':position(Context).
+
+advance_line(TokenLine) ->
+  Context = erlang:get(piper_cp_context),
+  'Elixir.Piper.Command.ParseContext':start_line(Context, TokenLine).
+
+advance_count(Count) ->
+  Context = erlang:get(piper_cp_context),
+  'Elixir.Piper.Command.ParseContext':advance_count(Context, Count).
+

--- a/src/piper_cmd2_name_lexer.xrl
+++ b/src/piper_cmd2_name_lexer.xrl
@@ -1,0 +1,20 @@
+Definitions.
+
+NAME                        = [a-z][a-zA-Z0-9_\-]*
+HIPCHAT_EMOJI               = \([a-zA-Z0-9_\-\+]+\)
+SLACK_EMOJI                 = :[a-zA-Z0-9_\-\+]+:
+COLON                       = :
+BAD_HIPCHAT_EMOJI           = \([a-zA-Z0-9_\-\+]+
+
+Rules.
+
+{NAME}                      : {token, {name, ?advance_count(TokenChars), TokenChars}}.
+{HIPCHAT_EMOJI}             : {token, {emoji, ?advance_count(TokenChars), TokenChars}}.
+{SLACK_EMOJI}               : {token, {emoji, ?advance_count(TokenChars), TokenChars}}.
+{COLON}                     : {token, {colon, ?advance_count(TokenChars), ":"}}.
+{BAD_HIPCHAT_EMOJI}         : {error, ["HipChat emoji missing paren: \"", TokenChars, "\""]}.
+
+
+Erlang code.
+
+-include("piper_cmd2_lexer.hrl").

--- a/src/piper_cmd2_name_parser.yrl
+++ b/src/piper_cmd2_name_parser.yrl
@@ -1,0 +1,36 @@
+Terminals
+
+name emoji colon.
+
+Nonterminals
+
+call qualified_call unqualified_call.
+
+Rootsymbol call.
+
+call ->
+  qualified_call : '$1'.
+call ->
+  unqualified_call : '$1'.
+
+qualified_call ->
+  name colon name : ?new_ast(name, [[{bundle, name_to_string('$1')},
+                                     {entity, name_to_string('$3')}]]).
+qualified_call ->
+  name colon emoji : ?new_ast(name, [[{bundle, name_to_string('$1')},
+                                      {entity, name_to_string('$3')}]]).
+
+unqualified_call ->
+  name : ?new_ast(name, [[{entity, name_to_string('$1')}]]).
+unqualified_call ->
+  emoji : ?new_ast(name, [[{entity, '$1'}]]).
+
+Erlang code.
+
+-include("piper_cmd2_parser.hrl").
+
+name_to_string({name, Position, Value}) ->
+  {string, Position, Value};
+name_to_string({emoji, Position, Value}) ->
+  {string, Position, Value}.
+

--- a/src/piper_cmd2_parser.hrl
+++ b/src/piper_cmd2_parser.hrl
@@ -1,0 +1,7 @@
+-define(parser_util, piper_cmd2_parser_util).
+-define(parse_token, piper_cmd2_parser_util:parse_token).
+-define(new_ast, piper_cmd2_parser_util:new_ast).
+
+-ifndef(NO_ERROR).
+-export([return_error/2]).
+-endif.

--- a/src/piper_cmd2_parser.yrl
+++ b/src/piper_cmd2_parser.yrl
@@ -1,0 +1,142 @@
+Terminals
+
+%% Notation
+pipe iff redir_multi redir_one
+
+%% Types
+text squoted_text dquoted_text.
+
+Nonterminals
+
+pipeline stages invocation args redirect targets.
+
+Rootsymbol pipeline.
+
+pipeline ->
+  stages : ?new_ast(pipeline, ['$1']).
+
+stages ->
+  invocation : ?new_ast(pipeline_stage, ['$1']).
+stages ->
+  invocation pipe stages : ?new_ast(pipeline_stage, ['$2', '$1', '$3']).
+stages ->
+  invocation iff stages : ?new_ast(pipeline_stage, ['$2', '$1', '$3']).
+
+invocation ->
+  text : Name = ?parse_token('$1', name, fun(Name) -> Name end),
+         ?new_ast(invocation, [Name]).
+invocation ->
+  text redirect : Name = ?parse_token('$1', name, fun(Name) -> Name end),
+                  ?new_ast(invocation, [Name, [{redir, '$2'}]]).
+
+invocation ->
+  text args : Name = ?parse_token('$1', name, fun(Name) -> Name end),
+              ?new_ast(invocation, [Name, [{args, validate_args('$2')}]]).
+invocation ->
+  text args redirect : Name = ?parse_token('$1', name, fun(Name) -> Name end),
+                       ?new_ast(invocation, [Name, [{args, validate_args('$2')}, {redir, '$3'}]]).
+
+redirect ->
+  redir_multi targets : ?new_ast(redirect, ['$1', '$2']).
+redirect ->
+  redir_one targets : ?new_ast(redirect, ['$1', '$2']).
+
+targets ->
+  text : [?new_ast(string, [text_to_string(validate_redirect_target('$1'))])].
+targets ->
+  text targets : [?new_ast(string, [text_to_string(validate_redirect_target('$1'))])] ++ '$2'.
+
+args ->
+  text : [?parse_token('$1', arg, fun(Arg) -> Arg end)].
+args ->
+  squoted_text : [ensure_quote_type_set(I, squote) || I <- [?parse_token(strip_quotes('$1'), interp, fun(Arg) -> Arg end)]].
+args ->
+  dquoted_text : [ensure_quote_type_set(I, dquote) || I <- [?parse_token(strip_quotes('$1'), interp, fun(Arg) -> Arg end)]].
+args ->
+  text args : [?parse_token('$1', arg, fun(Arg) -> Arg end)] ++ '$2'.
+args ->
+  squoted_text args : [ensure_quote_type_set(I, squote) || I <- [?parse_token(strip_quotes('$1'), interp, fun(Arg) -> Arg end)]] ++ '$2'.
+args ->
+  dquoted_text args : [ensure_quote_type_set(I, dquote) || I <- [?parse_token(strip_quotes('$1'), interp, fun(Arg) -> Arg end)]] ++ '$2'.
+
+Erlang code.
+
+-include("piper_cmd2_parser.hrl").
+
+-export([parse_pipeline/1]).
+
+parse_pipeline(Text) when is_binary(Text) ->
+  parse_pipeline(binary_to_list(Text));
+parse_pipeline(Text) ->
+  case piper_cmd2_lexer:scan(Text) of
+    {ok, Tokens, _} ->
+      try parse(Tokens) of
+          {ok, Results} ->
+            {ok, Results};
+          {error, _}=Reason ->
+            format_reason(Reason)
+      catch
+        Reason ->
+          format_reason(Reason)
+      end;
+    {error, {_, _, Error}, _} ->
+      {error, iolist_to_binary(piper_cmd2_lexer:format_error(Error))}
+  end.
+
+format_reason({error, {_, _, Reason}}) when is_list(Reason) ->
+  {error, iolist_to_binary(Reason)};
+format_reason({error, {_, _, Reason}}) ->
+  format_reason(Reason);
+format_reason(Reason) when is_map(Reason) ->
+  case maps:get('__struct__', Reason) of
+    'Elixir.Piper.Command.SemanticError' ->
+      Reason;
+    _ ->
+      {error, Reason}
+  end.
+
+strip_quotes({_, Position, [$"|_]=Text}) ->
+  {string, Position, re:replace(Text, "^\"|\"$", "", [{return, list}, global])};
+strip_quotes({_, Position, [$'|_]=Text}) ->
+  {string, Position, re:replace(Text, "^'|'$", "", [{return, list}, global])}.
+
+text_to_string({text, Position, Value}) ->
+  {string, Position, Value}.
+
+validate_redirect_target({_, _, [$c,$h,$a,$t,$:,$/,$/|_]}=Target) ->
+  Target;
+validate_redirect_target({_, {Line, Col}, [$c,$h,$a,$t,$:|_]}) ->
+  return_error({Line, Col}, "URL redirect targets must begin with chat://.");
+validate_redirect_target(Target) -> Target.
+
+validate_args(Args) ->
+  validate_args(Args, []).
+
+validate_args([], Accum) ->
+  lists:reverse(Accum);
+validate_args([H|T], Accum) when is_map(H) ->
+  case maps:find('__struct__', H) of
+    {ok, 'Elixir.Piper.Command.Ast.Option'} ->
+      case maps:get(value, H) of
+        next_arg ->
+          case T of
+            [Arg|T1] ->
+              H1 = maps:put(value, Arg, H),
+              validate_args(T1, [H1|Accum]);
+            _ ->
+              return_error({0, 0}, io_lib:format("Missing value for option '~p'", [maps:get(name, H)]))
+          end;
+        _ ->
+          validate_args(T, [H|Accum])
+      end;
+    _ ->
+      validate_args(T, [H|Accum])
+  end.
+
+ensure_quote_type_set(Value, QuoteType) ->
+  case maps:find(quote_type, Value) of
+    error ->
+      Value;
+    {ok, _} ->
+      maps:put(quote_type, QuoteType, Value)
+  end.

--- a/src/piper_cmd2_parser_util.erl
+++ b/src/piper_cmd2_parser_util.erl
@@ -1,0 +1,76 @@
+-module(piper_cmd2_parser_util).
+
+-export([parse_token/3,
+         parse_token/4,
+         new_ast/2]).
+
+parse_token(Token, Name, Handler) ->
+  parse_token(Token, Name, Name, Handler).
+
+parse_token({_, {Line, _} = Position, Value}, Lexer, Parser, Handler) ->
+  Context = erlang:get(piper_cp_context),
+  Old = 'Elixir.Piper.Command.ParseContext':position(Context),
+  'Elixir.Piper.Command.ParseContext':set_position(Context, Position),
+  LexerMod = lexer_for_name(Lexer),
+  ParserMod = parser_for_name(Parser),
+  try
+    case LexerMod:string(Value) of
+      {ok, Tokens, _} ->
+        case ParserMod:parse(Tokens) of
+          {ok, Results} ->
+            Handler(Results);
+          Error ->
+            ParserMod:return_error(Line, Error)
+        end;
+      {error, {_, _, Error}, _} ->
+        ParserMod:return_error(Line, LexerMod:format_error(Error))
+    end
+  after
+    'Elixir.Piper.Command.ParseContext':set_position(Context, Old)
+  end.
+
+new_ast(Name, Args) ->
+  apply(ast_node_for_name(Name), new, Args).
+
+lexer_for_name(name) ->
+  piper_cmd2_name_lexer;
+lexer_for_name(arg) ->
+  piper_cmd2_arg_lexer;
+lexer_for_name(var) ->
+  piper_cmd2_var_lexer;
+lexer_for_name(interp) ->
+  piper_cmd2_interp_lexer.
+
+parser_for_name(name) ->
+  piper_cmd2_name_parser;
+parser_for_name(arg) ->
+  piper_cmd2_arg_parser;
+parser_for_name(var) ->
+  piper_cmd2_var_parser;
+parser_for_name(interp) ->
+  piper_cmd2_interp_parser.
+
+ast_node_for_name(integer) ->
+  'Elixir.Piper.Command.Ast.Integer';
+ast_node_for_name(float) ->
+  'Elixir.Piper.Command.Ast.Float';
+ast_node_for_name(bool) ->
+  'Elixir.Piper.Command.Ast.Bool';
+ast_node_for_name(string) ->
+  'Elixir.Piper.Command.Ast.String';
+ast_node_for_name(option) ->
+  'Elixir.Piper.Command.Ast.Option';
+ast_node_for_name(name) ->
+  'Elixir.Piper.Command.Ast.Name';
+ast_node_for_name(invocation) ->
+  'Elixir.Piper.Command.Ast.Invocation';
+ast_node_for_name(pipeline_stage) ->
+  'Elixir.Piper.Command.Ast.PipelineStage';
+ast_node_for_name(pipeline) ->
+  'Elixir.Piper.Command.Ast.Pipeline';
+ast_node_for_name(redirect) ->
+  'Elixir.Piper.Command.Ast.Redirect';
+ast_node_for_name(variable) ->
+  'Elixir.Piper.Command.Ast.Variable';
+ast_node_for_name(interp_string) ->
+  'Elixir.Piper.Command.Ast.InterpolatedString'.

--- a/src/piper_cmd2_var_lexer.xrl
+++ b/src/piper_cmd2_var_lexer.xrl
@@ -1,0 +1,26 @@
+Definitions.
+
+VARIABLE               = \$[a-zA-Z]([a-zA-Z0-9_\-])*
+LBRACKET               = \[
+RBRACKET               = \]
+DOT                    = \.
+INTEGER                = [0-9]+
+TEXT                   = ([^\$\[\]\.])+
+
+Rules.
+
+{VARIABLE}             : {token, {variable, ?advance_count(TokenChars), TokenChars}}.
+{LBRACKET}             : {token, {lbracket, ?advance_count(TokenChars), "["}}.
+{RBRACKET}             : {token, {rbracket, ?advance_count(TokenChars), "]"}}.
+{DOT}                  : {token, {dot, ?advance_count(TokenChars), "."}}.
+{INTEGER}              : {token, {integer, ?advance_count(TokenChars), TokenChars}}.
+{TEXT}                 : {token, {text, ?advance_count(TokenChars), TokenChars}}.
+
+Erlang code.
+
+-export([possible_varexpr/1]).
+
+-include("piper_cmd2_lexer.hrl").
+
+possible_varexpr({_, _, Value}) ->
+  re:run(Value, "^\\$", [{capture, none}]) == match.

--- a/src/piper_cmd2_var_parser.yrl
+++ b/src/piper_cmd2_var_parser.yrl
@@ -1,0 +1,60 @@
+Terminals
+
+%% Types
+variable integer text
+
+%% Notation
+lbracket rbracket dot.
+
+Nonterminals
+
+varexpr varops.
+
+Rootsymbol varexpr.
+
+varexpr ->
+  variable : make_variable('$1').
+varexpr ->
+  variable varops : make_variable('$1', '$2').
+
+varops ->
+  lbracket integer rbracket : [{index, index_value('$2')}].
+varops ->
+  lbracket variable rbracket : [{index, make_variable('$2')}].
+varops ->
+  lbracket variable varops rbracket : [{index, make_variable('$2', '$3')}].
+varops ->
+  lbracket text rbracket : [{key, key_value('$2')}].
+varops ->
+  lbracket integer rbracket varops : [{index, index_value('$2')}] ++ '$4'.
+varops ->
+  lbracket variable rbracket varops : [{index, make_variable('$2')}] ++ '$4'.
+varops ->
+  lbracket variable varops rbracket varops : [{index, make_variable('$2', '$3')}] ++ '$5'.
+varops ->
+  lbracket text rbracket varops : [{key, key_value('$2')}] ++ '$4'.
+varops ->
+  dot text : [{key, key_value('$2')}].
+varops ->
+  dot text varops : [{key, key_value('$2')}] ++ '$3'.
+
+Erlang code.
+
+-include("piper_cmd2_parser.hrl").
+
+index_value({integer, _, Value}) ->
+  list_to_integer(Value).
+
+key_value({text, _, [$'|_]=Value}) ->
+  re:replace(Value, "^'|'$", "", [{return, binary}, global]);
+key_value({text, _, [$"|_]=Value}) ->
+  re:replace(Value, "^\"|\"$", "", [{return, binary}, global]);
+key_value({text, _, Value}) ->
+  list_to_binary(Value).
+
+make_variable(Var) ->
+  make_variable(Var, []).
+
+make_variable({variable, Position, Name}, Ops) ->
+  Var1 = {variable, Position, re:replace(Name, "^\\$", "", [{return, list}, global])},
+  ?new_ast(variable, [Var1, Ops]).

--- a/src/piper_cmd_lexer.xrl
+++ b/src/piper_cmd_lexer.xrl
@@ -28,34 +28,34 @@ NEWLINE                    = (\n|\r\n)
 
 Rules.
 
-{PIPE}                     : advance_count(length(TokenChars)), {token, {pipe, position(), "|"}}.
-{IFF}                      : advance_count(length(TokenChars)), {token, {iff, position(), "&&"}}.
-{REDIR_MULTI}              : advance_count(length(TokenChars)), {token, {redir_multi, position(), "*>"}}.
-{REDIR_ONE}                : advance_count(length(TokenChars)), {token, {redir_one, position(), ">"}}.
-{LBRACKET}                 : advance_count(length(TokenChars)), {token, {lbracket, position(), "["}}.
-{RBRACKET}                 : advance_count(length(TokenChars)), {token, {rbracket, position(), "]"}}.
-{WS}{COLON}                : advance_count(length(TokenChars)), {token, {bad_colon, position(), ":"}}.
-{COLON}{WS}                : advance_count(length(TokenChars)), {token, {bad_colon, position(), ":"}}.
-{COLON}                    : advance_count(length(TokenChars)), {token, {colon, position(), ":"}}.
-{SLASH}                    : advance_count(length(TokenChars)), {token, {slash, position(), "/"}}.
-{EQUALS}                   : advance_count(length(TokenChars)), {token, {equals, position(), "="}}.
-{DOT}                      : advance_count(length(TokenChars)), {token, {dot, position(), "."}}.
-{WS}{SLACK_EMOJI}          : advance_count(length(TokenChars)), {token, {emoji, position(), tl(TokenChars)}}.
-{SLACK_EMOJI}              : advance_count(length(TokenChars)), {token, {emoji, position(), TokenChars}}.
-{HIPCHAT_EMOJI}            : advance_count(length(TokenChars)), {token, {emoji, position(), TokenChars}}.
-{VAR}                      : advance_count(length(TokenChars)), {token, {variable, position(), tl(TokenChars)}}.
-{TRUE}                     : advance_count(length(TokenChars)), {token, {bool, position(), "true"}}.
-{FALSE}                    : advance_count(length(TokenChars)), {token, {bool, position(), "false"}}.
-{VERSION}                  : advance_count(length(TokenChars)), {token, {string, position(), TokenChars}}.
-{FLOAT}                    : advance_count(length(TokenChars)), {token, {float, position(), TokenChars}}.
-{INTEGER}                  : advance_count(length(TokenChars)), {token, {integer, position(), TokenChars}}.
-{DOUBLE_DASH}              : advance_count(length(TokenChars)), {token, {longopt, position(), "--"}}.
-{SINGLE_DASH}              : advance_count(length(TokenChars)), {token, {shortopt, position(), "-"}}.
-{NAME}                     : advance_count(length(TokenChars)), {token, {string, position(), TokenChars}}.
-{DQUOTED_STRING}           : advance_count(length(TokenChars)), {token, {string, position(), clean_dquotes(TokenChars)}}.
-{SQUOTED_STRING}           : advance_count(length(TokenChars)), {token, {string, position(), clean_squotes(TokenChars)}}.
-{DATUM}                    : advance_count(length(TokenChars)), {token, {datum, position(), TokenChars}}.
-{WS}                       : advance_count(length(TokenChars)), skip_token.
+{PIPE}                     : {token, {pipe, advance_count(length(TokenChars)), "|"}}.
+{IFF}                      : {token, {iff, advance_count(length(TokenChars)), "&&"}}.
+{REDIR_MULTI}              : {token, {redir_multi, advance_count(length(TokenChars)), "*>"}}.
+{REDIR_ONE}                : {token, {redir_one, advance_count(length(TokenChars)), ">"}}.
+{LBRACKET}                 : {token, {lbracket, advance_count(length(TokenChars)), "["}}.
+{RBRACKET}                 : {token, {rbracket, advance_count(length(TokenChars)), "]"}}.
+{WS}{COLON}                : {token, {bad_colon, advance_count(length(TokenChars)), ":"}}.
+{COLON}{WS}                : {token, {bad_colon, advance_count(length(TokenChars)), ":"}}.
+{COLON}                    : {token, {colon, advance_count(length(TokenChars)), ":"}}.
+{SLASH}                    : {token, {slash, advance_count(length(TokenChars)), "/"}}.
+{EQUALS}                   : {token, {equals, advance_count(length(TokenChars)), "="}}.
+{DOT}                      : {token, {dot, advance_count(length(TokenChars)), "."}}.
+{WS}{SLACK_EMOJI}          : {token, {emoji, advance_count(length(TokenChars)), tl(TokenChars)}}.
+{SLACK_EMOJI}              : {token, {emoji, advance_count(length(TokenChars)), TokenChars}}.
+{HIPCHAT_EMOJI}            : {token, {emoji, advance_count(length(TokenChars)), TokenChars}}.
+{VAR}                      : {token, {variable, advance_count(length(TokenChars)), tl(TokenChars)}}.
+{TRUE}                     : {token, {bool, advance_count(length(TokenChars)), "true"}}.
+{FALSE}                    : {token, {bool, advance_count(length(TokenChars)), "false"}}.
+{VERSION}                  : {token, {string, advance_count(length(TokenChars)), TokenChars}}.
+{FLOAT}                    : {token, {float, advance_count(length(TokenChars)), TokenChars}}.
+{INTEGER}                  : {token, {integer, advance_count(length(TokenChars)), TokenChars}}.
+{DOUBLE_DASH}              : {token, {longopt, advance_count(length(TokenChars)), "--"}}.
+{SINGLE_DASH}              : {token, {shortopt, advance_count(length(TokenChars)), "-"}}.
+{NAME}                     : {token, {string, advance_count(length(TokenChars)), TokenChars}}.
+{DQUOTED_STRING}           : {token, {string, advance_count(length(TokenChars)), clean_dquotes(TokenChars)}}.
+{SQUOTED_STRING}           : {token, {string, advance_count(length(TokenChars)), clean_squotes(TokenChars)}}.
+{DATUM}                    : {token, {datum, advance_count(length(TokenChars)), TokenChars}}.
+{WS}                       : skip_token.
 {NEWLINE}+                 : advance_line(TokenLine), skip_token.
 
 Erlang code.
@@ -93,10 +93,6 @@ tokenize(Text) when is_list(Text) ->
 init(MaxDepth) ->
   {ok, Context} = 'Elixir.Piper.Command.ParseContext':start_link(MaxDepth),
   erlang:put(piper_cp_context, Context).
-
-position() ->
-  Context = erlang:get(piper_cp_context),
-  'Elixir.Piper.Command.ParseContext':position(Context).
 
 advance_line(TokenLine) ->
   Context = erlang:get(piper_cp_context),

--- a/test/command/exec/interpolation_test.exs
+++ b/test/command/exec/interpolation_test.exs
@@ -1,0 +1,22 @@
+defmodule Bind.InterpolationTest do
+
+  use ExUnit.Case
+
+  alias Piper.Common.Scope
+
+  use Piper.Test.BindHelpers
+
+  test "basic string interpolation works" do
+    scope = Scope.from_map(%{"value" => "a test"})
+    {:ok, ast} = parse_and_bind2("echo \"this is ${value}\"", scope)
+    assert "#{ast}" == "echo this is a test"
+  end
+
+  test "string interpolation with varops works" do
+    scope = Scope.from_map(%{"users" => [%{"userid" => 100, "username" => "bob"},
+                                         %{"userid" => 101, "username" => "linda"}]})
+    {:ok, ast} = parse_and_bind2("echo \"${users[0].username} has id ${users[0].userid}\"", scope)
+    assert "#{ast}" == "echo bob has id 100"
+  end
+
+end

--- a/test/command/exec/legacy_bind_test.exs
+++ b/test/command/exec/legacy_bind_test.exs
@@ -1,11 +1,11 @@
-defmodule Bind.BindTest do
+defmodule Bind.LegacyBindTest do
 
   use ExUnit.Case
 
   alias Piper.Common.Scope
   alias Piper.Command.Ast, as: Ast
 
-  use Piper.Test.BindHelpers
+  use Piper.Test.BindHelpers, legacy: true
 
   defp arg(%Ast.Pipeline{}=ast, index) do
     Enum.at(ast.stages.left.args, index)

--- a/test/command/exec/legacy_expansion_test.exs
+++ b/test/command/exec/legacy_expansion_test.exs
@@ -1,0 +1,39 @@
+defmodule Piper.LegacyExpansionTest do
+
+  use ExUnit.Case
+  alias Parser.TestHelpers
+  alias Piper.Command.Parser
+
+  test "infinite expansion triggers error" do
+    {:error, message} = Parser.scan_and_parse("night", TestHelpers.expansion_options(true))
+    assert message == "Infinite alias expansion loop detected 'mare' -> 'night'."
+  end
+
+  test "wide infinite expansion is detected" do
+    {:error, message} = Parser.scan_and_parse("hello | alpha", TestHelpers.expansion_options(true))
+    assert message == "Infinite alias expansion loop detected 'gamma' -> 'alpha'."
+  end
+
+  test "expanding alias with one step" do
+    {:ok, ast} = Parser.scan_and_parse("one", TestHelpers.expansion_options(true))
+    assert "#{ast}" == "greetings:hello"
+  end
+
+  test "expanding alias with two steps" do
+    {:ok, ast} = Parser.scan_and_parse("two", TestHelpers.expansion_options(true))
+    assert "#{ast}" == "greetings:hello"
+    {:ok, ast} = Parser.scan_and_parse("two | one | two | two", TestHelpers.expansion_options(true))
+    assert "#{ast}" == "greetings:hello | greetings:hello | greetings:hello | greetings:hello"
+  end
+
+  test "expanding aliases at expansion limit" do
+    {:ok, ast} = Parser.scan_and_parse("four | three | one | four", TestHelpers.expansion_options(true))
+    assert "#{ast}" == "greetings:hello | greetings:hello | greetings:hello | greetings:hello"
+  end
+
+  test "expanding aliases over expansion limit" do
+    {:error, message} = Parser.scan_and_parse("seven", TestHelpers.expansion_options(true))
+    assert message == "Alias expansion limit (5) exceeded starting with alias 'seven'."
+  end
+
+end

--- a/test/command/parser/lexer_test.exs
+++ b/test/command/parser/lexer_test.exs
@@ -1,5 +1,5 @@
 defmodule Parser.LexerTest do
-  use Parser.ParsingCase
+  use Parser.ParsingCase, legacy: true
 
   test "lexing whitespace returns empty token list" do
     assert {:ok, []} == Lexer.tokenize(" ", 5)

--- a/test/permissions/parser_test.exs
+++ b/test/permissions/parser_test.exs
@@ -30,8 +30,8 @@ defmodule Piper.Permissions.ParserTest do
 
   # Generates randomized amount of white space
   defp ws() do
-    :random.seed(:os.timestamp())
-    String.duplicate(" ", :random.uniform(7) + 1)
+    :rand.seed(:exs1024, :os.timestamp())
+    String.duplicate(" ", :rand.uniform(7) + 1)
   end
 
   # Normalize more than 1 space character to 1.

--- a/test/support/bind_helpers.ex
+++ b/test/support/bind_helpers.ex
@@ -1,0 +1,53 @@
+defmodule Piper.Test.BindHelpers do
+
+  alias Piper.Command.Parser
+  alias Piper.Command.ParserOptions
+  alias Piper.Common.Scope
+
+  defmacro __using__(opts \\ []) do
+    use_legacy = Keyword.get(opts, :legacy, false)
+    quote do
+      import unquote(__MODULE__), only: [link_scopes: 1,
+                                         make_scope_chain: 1]
+
+      def parse_and_bind(text) do
+        parse_and_bind(text, Scope.empty_scope())
+      end
+
+      def parse_and_bind(text, vars) when is_map(vars) do
+        scope = Scope.from_map(vars)
+        parse_and_bind2(text, scope)
+      end
+
+      def parse_and_bind2(text, scope, opts \\ %ParserOptions{}) do
+        opts = %{opts | use_legacy_parser: unquote(use_legacy)}
+        {:ok, ast} = Parser.scan_and_parse(text, opts)
+        case Scope.bind(ast, scope) do
+          {:ok, new_ast, _scope} ->
+            {:ok, new_ast}
+          error ->
+            error
+        end
+      end
+
+    end
+  end
+
+  def link_scopes([]) do
+    Scope.empty_scope()
+  end
+  def link_scopes(vars) do
+    make_scope_chain(Enum.reverse(vars))
+  end
+
+  def make_scope_chain([h]) do
+    Scope.from_map(h)
+  end
+  def make_scope_chain([h|t]) do
+    parent = make_scope_chain(t)
+    scope = Scope.from_map(h)
+    {:ok, scope} = Scope.Scoped.set_parent(scope, parent)
+    scope
+  end
+
+end

--- a/test/support/parsing_case.ex
+++ b/test/support/parsing_case.ex
@@ -2,9 +2,15 @@ defmodule Parser.ParsingCase do
 
   require Logger
 
-  defmacro __using__(_) do
+  defmacro __using__(opts \\ []) do
+    use_legacy = Keyword.get(opts, :legacy, false)
+    lexer_name = if use_legacy do
+      :piper_cmd_lexer
+    else
+      :piper_cmd2_lexer
+    end
     quote do
-      alias :piper_cmd_lexer, as: Lexer
+      alias unquote(lexer_name), as: Lexer
       alias Piper.Command.Parser
       alias Piper.Command.ParserOptions
       use ExUnit.Case
@@ -13,6 +19,11 @@ defmodule Parser.ParsingCase do
                                          text: 1,
                                          ast_string: 1,
                                          matches: 2]
+
+      defp parse_text(text) do
+        opts = %ParserOptions{use_legacy_parser: unquote(use_legacy)}
+        Parser.scan_and_parse(text, opts)
+      end
     end
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -2,20 +2,24 @@ defmodule Parser.TestHelpers do
 
   alias Piper.Command.ParserOptions
 
-  def parser_options() do
-    %ParserOptions{resolver: &resolve_commands/2}
+  def parser_options(use_legacy \\ false) do
+    %ParserOptions{resolver: &resolve_commands/2,
+                   use_legacy_parser: use_legacy}
   end
 
-  def expansion_options() do
-    %ParserOptions{resolver: &expand_commands/2}
+  def expansion_options(use_legacy \\ false) do
+    %ParserOptions{resolver: &expand_commands/2,
+                   use_legacy_parser: use_legacy}
   end
 
-  def gnarly_options() do
-    %ParserOptions{resolver: &gnarly_expansions/2}
+  def gnarly_options(use_legacy \\ false) do
+    %ParserOptions{resolver: &gnarly_expansions/2,
+                   use_legacy_parser: use_legacy}
   end
 
-  def redirect_options() do
-    %ParserOptions{resolver: &redirect_expansions/2}
+  def redirect_options(use_legacy \\ false) do
+    %ParserOptions{resolver: &redirect_expansions/2,
+                   use_legacy_parser: use_legacy}
   end
 
 


### PR DESCRIPTION
Summary:

- Previously monolithic parsing logic split into a suite of composable
  parsers
- Relaxed grammar more closely follows typical command shell parsing
  behavior
- Introduces string interpolation support

Details:

This commit adds a new command parser which features a more relaxed
parsing grammar and support for string interpolation. This is achieved
by breaking out the lexing and parsing logic for major data types --
pipelines, names, args/options, variables, and interpolated strings --
into separate lexer/parser pairs which are combined to create the final
command parsing pipeline.

In the vast majority of cases the new parser produces identical AST
when compared against the existing parser. Aside from the new features
the only difference between the old and new parsers is their handling of
quoted strings. The old parser parsed them correctly but dropped the
strings when converting the AST to a string whereas the new parser
preserves quoting.

`Piper.Command.Parser` and `Piper.Command.ParserOptions` have been
changed to make the old and new parsers swappable. Setting the
`use_legacy_parser` field on `ParserOptions` to `true` will cause Piper
to parse command input with the old parser.

The command parser's test suite has been changed to cover new features
and ensure the legacy parser continues to work. First, the test modules
for variable binding, alias expansion, command lexing, and command
parsing were split into two "forks". The legacy fork captures these test
modules in their current state and runs them against the legacy
parser. These modules are prefixed with `Legacy`. The new fork, which
consists of the same test modules but retaining their non-legacy names,
have been extended to exercise the new parser.

Fixes operable/cog#1082