### PR TITLE
Support git-like command names

### DIFF
--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -22,6 +22,32 @@ defmodule Parser.TestHelpers do
                    use_legacy_parser: use_legacy}
   end
 
+  def hyphenated_command_options(use_legacy \\ false) do
+    %ParserOptions{resolver: &resolve_hyphenated_commands/2,
+                   use_legacy_parser: use_legacy}
+  end
+
+  def long_command_options(use_legacy \\ false) do
+    %ParserOptions{resolver: &resolve_long_commands/2,
+                   use_legacy_parser: use_legacy}
+  end
+
+  def resolve_hyphenated_commands(bundle, cmd) do
+    if String.contains?(cmd, "-") do
+      {:command, {bundle, cmd}}
+    else
+      :not_found
+    end
+  end
+
+  def resolve_long_commands(_bundle, cmd) do
+    case String.split(cmd, "-") do
+      ["stack", "purge", "delete"] ->
+        {:command, {"cfn", cmd}}
+      _ ->
+        :not_found
+    end
+  end
 
   def resolve_commands(_bundle, cmd) when cmd in ["hello", "goodbye"] do
     {:command, {"salutations", cmd}}


### PR DESCRIPTION
This PR adds support for git-like parsing of command names in an
effort to improve Cog's CLI usability. Concretely, command names
containing hyphens are inferred from user input as long as the head of
the arg list is a string.

Let's work thru an example to see how this works. Assume we have a EC2
bundle installed which contains a command named `instances-list`. Prior
to this change the only ways to invoke the command would be for the user
to refer to it as `ec2:instances-list` or `instances-list`.

This change continues to support the above references and adds a third,
subcommand-like reference: `ec2:instances list`. This works for any
number of hyphens so long as the head of the arg list is a string. Taken
to an extreme, the command `ec2:instances-list-and-purge` can be
referenced in all the following ways: `ec2:instances-list-and-purge`,
`instances-list-and-purge`, `ec2:instances list and purge`, `instances
list and purge`, etc.

Parsing hyphenated commands as subcommands is achieved by modifying the
logic used by `Piper.Command.Parser` to resolve commands during parse
time. The revised logic looks like this:

1. Call the resolver with the current bundle and command name.
1. If the command name is found, stop and return the pipeline (in case
of expanded aliases) or bundle and commmand (in case of commands).
1. If the first arg is a string:
  1. Create a new command name by concatenating the first arg onto
  the command name separated by a hyphen.
  1. Goto 1.
1. If the first arg is not a string, return `:not_found`.

Fixes operable/cog#1091