### PR TITLE
Error messages

### DIFF
--- a/lib/piper/command/semantic_error.ex
+++ b/lib/piper/command/semantic_error.ex
@@ -25,6 +25,9 @@ defmodule Piper.Command.SemanticError do
   defp message_for_reason(:not_found, text, _) do
     "Command '#{text}' not found in any installed bundle."
   end
+  defp message_for_reason(:not_in_bundle, text, bundle) do
+    "Command '#{text}' not be found in '#{bundle}'. See 'help #{bundle}' for information on the bundle."
+  end
   defp message_for_reason(:not_enabled, _, bundle) do
     "Bundle '#{bundle}' is not enabled. " <>
     "See 'help operable:bundle' for information on enabling bundles."

--- a/lib/piper/command/semantic_error.ex
+++ b/lib/piper/command/semantic_error.ex
@@ -26,11 +26,10 @@ defmodule Piper.Command.SemanticError do
     "Command '#{text}' not found in any installed bundle."
   end
   defp message_for_reason(:not_in_bundle, text, bundle) do
-    "Command '#{text}' not be found in '#{bundle}'. See 'help #{bundle}' for information on the bundle."
+    "Bundle '#{bundle}' doesn't contain a command named '#{text}'."
   end
   defp message_for_reason(:not_enabled, _, bundle) do
-    "Bundle '#{bundle}' is not enabled. " <>
-    "See 'help operable:bundle' for information on enabling bundles."
+    "Bundle '#{bundle}' is disabled. Please enable it and try running the command again."
   end
   defp message_for_reason(:ambiguous, text, bundles) do
     "Ambiguous command reference detected. " <>

--- a/lib/piper/command/semantic_error.ex
+++ b/lib/piper/command/semantic_error.ex
@@ -25,6 +25,10 @@ defmodule Piper.Command.SemanticError do
   defp message_for_reason(:not_found, text, _) do
     "Command '#{text}' not found in any installed bundle."
   end
+  defp message_for_reason(:not_enabled, _, bundle) do
+    "Bundle '#{bundle}' is not enabled. " <>
+    "See 'help operable:bundle' for information on enabling bundles."
+  end
   defp message_for_reason(:ambiguous, text, bundles) do
     "Ambiguous command reference detected. " <>
     "Command '#{text}' found in bundles #{format_bundles(bundles)}."

--- a/lib/piper/command/semantic_error.ex
+++ b/lib/piper/command/semantic_error.ex
@@ -4,29 +4,13 @@ defmodule Piper.Command.SemanticError do
              :meta]
 
 
-  def new(near, :not_found) do
+  def new(near, {reason, meta}) do
     error = init(near)
-    %{error | reason: :not_found}
+    %{error | reason: reason, meta: meta}
   end
-  def new(near, {:ambiguous, bundles}) do
+  def new(near, reason) do
     error = init(near)
-    %{error | reason: :ambiguous, meta: bundles}
-  end
-  def new(near, {:bad_bundle, bundle}) do
-    error = init(near)
-    %{error | reason: :bad_bundle, meta: bundle}
-  end
-  def new(near, {:bad_command, command}) do
-    error = init(near)
-    %{error | reason: :bad_command, meta: command}
-  end
-  def new(near, {:expansion_limit, alias, limit}) do
-    error = init(near)
-    %{error | reason: :expansion_limit, meta: {alias, limit}}
-  end
-  def new(near, {:alias_cycle, cycle}) do
-    error = init(near)
-    %{error | reason: :alias_cycle, meta: cycle}
+    %{error | reason: reason}
   end
 
   def new({:syntax, message}) do

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -195,14 +195,14 @@ defmodule Parser.ParserTest do
     assert message == "Ambiguous command reference detected. Command 'multi' found in bundles 'a', 'b', and 'c'."
   end
 
-  test "not enabled commands fail resolution" do
+  test "disabled commands fail resolution" do
     {:error, message} = Parser.scan_and_parse("not_enabled", TestHelpers.parser_options())
-    assert message == "Bundle 'bundle1' is not enabled. See 'help operable:bundle' for information on enabling bundles."
+    assert message == "Bundle 'bundle1' is disabled. Please enable it and try running the command again."
   end
 
   test "commands not in the requested bundle fail resolution" do
     {:error, message} = Parser.scan_and_parse("not_in_bundle", TestHelpers.parser_options())
-    assert message == "Command 'not_in_bundle' not be found in 'bundle1'. See 'help bundle1' for information on the bundle."
+    assert message == "Bundle 'bundle1' doesn't contain a command named 'not_in_bundle'."
   end
 
   test "splicing aliases into parse tree" do

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -195,6 +195,11 @@ defmodule Parser.ParserTest do
     assert message == "Ambiguous command reference detected. Command 'multi' found in bundles 'a', 'b', and 'c'."
   end
 
+  test "not enabled commands fail resolution" do
+    {:error, message} = Parser.scan_and_parse("not_enabled", TestHelpers.parser_options())
+    assert message == "Bundle 'bundle1' is not enabled. See 'help operable:bundle' for information on enabling bundles."
+  end
+
   test "splicing aliases into parse tree" do
     {:ok, ast} = Parser.scan_and_parse("pipe1", TestHelpers.parser_options())
     assert "#{ast}" == "salutations:hello"

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -200,6 +200,11 @@ defmodule Parser.ParserTest do
     assert message == "Bundle 'bundle1' is not enabled. See 'help operable:bundle' for information on enabling bundles."
   end
 
+  test "commands not in the requested bundle fail resolution" do
+    {:error, message} = Parser.scan_and_parse("not_in_bundle", TestHelpers.parser_options())
+    assert message == "Command 'not_in_bundle' not be found in 'bundle1'. See 'help bundle1' for information on the bundle."
+  end
+
   test "splicing aliases into parse tree" do
     {:ok, ast} = Parser.scan_and_parse("pipe1", TestHelpers.parser_options())
     assert "#{ast}" == "salutations:hello"

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -36,7 +36,7 @@ defmodule Parser.TestHelpers do
     if String.contains?(cmd, "-") do
       {:command, {bundle, cmd}}
     else
-      :not_found
+      {:error, :not_found}
     end
   end
 
@@ -45,15 +45,12 @@ defmodule Parser.TestHelpers do
       ["stack", "purge", "delete"] ->
         {:command, {"cfn", cmd}}
       _ ->
-        :not_found
+        {:error, :not_found}
     end
   end
 
   def resolve_commands(_bundle, cmd) when cmd in ["hello", "goodbye"] do
     {:command, {"salutations", cmd}}
-  end
-  def resolve_commands(_bundle, "multi") do
-    {:ambiguous, ["a","b","c"]}
   end
   def resolve_commands(_bundle, "bogus") do
     {:command, {":foo", "bogus"}}
@@ -67,8 +64,11 @@ defmodule Parser.TestHelpers do
   def resolve_commands(_bundle, "pipe1") do
     {:pipeline, "hello"}
   end
+  def resolve_commands(_bundle, "multi") do
+    {:error, {:ambiguous, ["a","b","c"]}}
+  end
   def resolve_commands(_bundle, _name) do
-    :not_found
+    {:error, :not_found}
   end
 
   def expand_commands(_bundle, "night") do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -52,6 +52,9 @@ defmodule Parser.TestHelpers do
   def resolve_commands(_bundle, cmd) when cmd in ["hello", "goodbye"] do
     {:command, {"salutations", cmd}}
   end
+  def resolve_commands(_bundle, "multi") do
+    {:error, {:ambiguous, ["a","b","c"]}}
+  end
   def resolve_commands(_bundle, "bogus") do
     {:command, {":foo", "bogus"}}
   end
@@ -64,8 +67,8 @@ defmodule Parser.TestHelpers do
   def resolve_commands(_bundle, "pipe1") do
     {:pipeline, "hello"}
   end
-  def resolve_commands(_bundle, "multi") do
-    {:error, {:ambiguous, ["a","b","c"]}}
+  def resolve_commands(_bundle, "not_enabled") do
+    {:error, {:not_enabled, "bundle1"}}
   end
   def resolve_commands(_bundle, _name) do
     {:error, :not_found}

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -70,6 +70,9 @@ defmodule Parser.TestHelpers do
   def resolve_commands(_bundle, "not_enabled") do
     {:error, {:not_enabled, "bundle1"}}
   end
+  def resolve_commands(_bundle, "not_in_bundle") do
+    {:error, {:not_in_bundle, "bundle1"}}
+  end
   def resolve_commands(_bundle, _name) do
     {:error, :not_found}
   end


### PR DESCRIPTION
This change updates piper to return errors as a `Piper.Command.SemanticError` struct instead of translating errors into a string. We'll handle error string generation in Cog.

Note: We'll need to update Cog and whatever uses this lib to expect a SemanticError struct instead of a string.

reference https://github.com/operable/cog/issues/1092