### PR TITLE
Made parsing pipeline Unicode-aware

### DIFF
--- a/src/piper_cmd2_lexer.xrl
+++ b/src/piper_cmd2_lexer.xrl
@@ -46,9 +46,9 @@ apply_fixups(Tokens) -> apply_fixups(Tokens, []).
 apply_fixups([], Accum) -> lists:reverse(Accum);
 apply_fixups([{text, T1Pos, T1Text}=T1, {Quoted, _, QuotedValue}=QT, {text, _, T2Text}=T2|T], Accum) when Quoted == squoted_text;
                                                                                                           Quoted == dquoted_text ->
-  case re:run(T1Text, "\\[$", [{capture, none}]) of
+  case re:run(T1Text, "\\[$", [{capture, none}, unicode]) of
     match ->
-      case re:run(T2Text, "^\\]", [{capture, none}]) of
+      case re:run(T2Text, "^\\]", [{capture, none}, unicode]) of
         match ->
           Updated = {text, T1Pos, T1Text ++ QuotedValue ++ T2Text},
           apply_fixups([Updated|T], Accum);
@@ -56,7 +56,7 @@ apply_fixups([{text, T1Pos, T1Text}=T1, {Quoted, _, QuotedValue}=QT, {text, _, T
           apply_fixups([QT, T2|T], [T1|Accum])
       end;
     nomatch ->
-      case re:run(T1Text, "\\.$", [{capture, none}]) of
+      case re:run(T1Text, "\\.$", [{capture, none}, unicode]) of
         match ->
           Updated = {text, T1Pos, T1Text ++ QuotedValue},
           apply_fixups([Updated, T2|T], Accum);
@@ -67,7 +67,7 @@ apply_fixups([{text, T1Pos, T1Text}=T1, {Quoted, _, QuotedValue}=QT, {text, _, T
 apply_fixups([{text, T1Pos, T1Text}=T1, {TextType, _, T2Text}=T2|T], Accum) when TextType == text;
                                                                                  TextType == squoted_text;
                                                                                  TextType == dquoted_text ->
-  case re:run(T2Text, "(^\\.|^\\[)", [{capture, none}]) of
+  case re:run(T2Text, "(^\\.|^\\[)", [{capture, none}, unicode]) of
     match ->
       Updated = {text, T1Pos, T1Text ++ T2Text},
       apply_fixups([Updated|T], Accum);

--- a/src/piper_cmd2_parser.yrl
+++ b/src/piper_cmd2_parser.yrl
@@ -66,7 +66,7 @@ Erlang code.
 -export([parse_pipeline/1]).
 
 parse_pipeline(Text) when is_binary(Text) ->
-  parse_pipeline(binary_to_list(Text));
+  parse_pipeline(elixir_string_to_list(Text));
 parse_pipeline(Text) ->
   case piper_cmd2_lexer:scan(Text) of
     {ok, Tokens, _} ->
@@ -84,7 +84,7 @@ parse_pipeline(Text) ->
   end.
 
 format_reason({error, {_, _, Reason}}) when is_list(Reason) ->
-  {error, iolist_to_binary(Reason)};
+  {error, list_to_elixir_string(Reason)};
 format_reason({error, {_, _, Reason}}) ->
   format_reason(Reason);
 format_reason(Reason) when is_map(Reason) ->
@@ -96,9 +96,9 @@ format_reason(Reason) when is_map(Reason) ->
   end.
 
 strip_quotes({_, Position, [$"|_]=Text}) ->
-  {string, Position, re:replace(Text, "^\"|\"$", "", [{return, list}, global])};
+  {string, Position, re:replace(Text, "^\"|\"$", "", [{return, list}, global, unicode])};
 strip_quotes({_, Position, [$'|_]=Text}) ->
-  {string, Position, re:replace(Text, "^'|'$", "", [{return, list}, global])}.
+  {string, Position, re:replace(Text, "^'|'$", "", [{return, list}, global, unicode])}.
 
 text_to_string({text, Position, Value}) ->
   {string, Position, Value}.
@@ -140,3 +140,11 @@ ensure_quote_type_set(Value, QuoteType) ->
     {ok, _} ->
       maps:put(quote_type, QuoteType, Value)
   end.
+
+elixir_string_to_list(Text) when is_binary(Text) ->
+  'Elixir.String':to_charlist(Text).
+
+list_to_elixir_string(Text) when is_list(Text) ->
+  %% Ensure we're dealing with a flat list first
+  Text1 = lists:flatten(Text),
+  'Elixir.String.Chars':to_string(Text1).

--- a/src/piper_cmd2_var_lexer.xrl
+++ b/src/piper_cmd2_var_lexer.xrl
@@ -23,4 +23,4 @@ Erlang code.
 -include("piper_cmd2_lexer.hrl").
 
 possible_varexpr({_, _, Value}) ->
-  re:run(Value, "^\\$", [{capture, none}]) == match.
+  re:run(Value, "^\\$", [{capture, none}, unicode]) == match.


### PR DESCRIPTION
* Replaced uses of `:erlang.iolist_to_binary/1` and
  `:erlang.binary_to_list/1` with Elixir equivalents. This preserves
  Unicode encoding and ensures the generated parsers and lexers are
  operating on valid Unicode inputs.
 * Added the `unicode` option to all `re:run/3` and `re:replace/3` calls
  in the generated lexers and parsers. This prevents spurious errors
  when operating on Unicode inputs.
 * Added several test cases to protect against future regressions.

Fixes operable/cog#1133