### PR TITLE
Allow variable refs in interpolated strings

### DIFF
--- a/lib/piper/command/parser.ex
+++ b/lib/piper/command/parser.ex
@@ -92,7 +92,8 @@ defmodule Piper.Command.Parser do
           {:error, reason}
       end
     catch
-      error -> SemanticError.format_error(error)
+      error ->
+        SemanticError.format_error(error)
     after
       Process.delete(:piper_cp_context)
       ParseContext.stop(context)

--- a/src/piper_cmd2_interp_lexer.xrl
+++ b/src/piper_cmd2_interp_lexer.xrl
@@ -2,8 +2,11 @@ Definitions.
 
 INTERP_VALUE                    = \${([^\${}]|\\\$|\\{|\\})+}
 TEXT                            = (\\\^.|\\.|[^\$])+
+VAR_REF                         = \$([a-zA-Z0-9_\[\]\.]+)
+
 Rules.
 
+{VAR_REF}                       : {token, {text, ?advance_count(TokenChars), TokenChars}}.
 {INTERP_VALUE}                  : {token, {interp_value, ?advance_count(TokenChars), expr_text(TokenChars)}}.
 {TEXT}                          : {token, {text, ?advance_count(TokenChars), TokenChars}}.
 

--- a/src/piper_cmd2_interp_parser.yrl
+++ b/src/piper_cmd2_interp_parser.yrl
@@ -9,7 +9,7 @@ interpexpr parts.
 Rootsymbol interpexpr.
 
 interpexpr ->
-  parts : ?new_ast(interp_string, ['$1']).
+  parts : new_interpexpr('$1').
 
 parts ->
   text : [?new_ast(string, [text_to_string('$1')])].
@@ -26,3 +26,36 @@ Erlang code.
 
 text_to_string({text, Position, Value}) ->
   {string, Position, Value}.
+
+new_interpexpr(Values) ->
+  case are_all_strings(Values) of
+    true ->
+      concatenate_strings(Values);
+    false ->
+      ?new_ast(interp_string, [Values])
+  end.
+
+are_all_strings([]) -> true;
+are_all_strings([Str|T]) ->
+  case is_string(Str) of
+    true ->
+      are_all_strings(T);
+    false ->
+      false
+  end.
+
+concatenate_strings([Str]) -> Str;
+concatenate_strings([H|_]=Strings) ->
+  Values = [maps:get('value', Str) || Str <- Strings],
+  Updated = 'Elixir.Enum':join(Values),
+  maps:put('value', Updated, H).
+
+is_string(Str) when is_map(Str) ->
+  case maps:get('__struct__', Str) of
+    'Elixir.Piper.Command.Ast.String' ->
+      true;
+    _ ->
+      false
+  end;
+is_string(_) -> false.
+

--- a/src/piper_cmd2_parser.yrl
+++ b/src/piper_cmd2_parser.yrl
@@ -66,7 +66,7 @@ Erlang code.
 -export([parse_pipeline/1]).
 
 parse_pipeline(Text) when is_binary(Text) ->
-  parse_pipeline(elixir_string_to_list(Text));
+  parse_pipeline(?parser_util:elixir_string_to_list(Text));
 parse_pipeline(Text) ->
   case piper_cmd2_lexer:scan(Text) of
     {ok, Tokens, _} ->
@@ -84,7 +84,7 @@ parse_pipeline(Text) ->
   end.
 
 format_reason({error, {_, _, Reason}}) when is_list(Reason) ->
-  {error, list_to_elixir_string(Reason)};
+  {error, ?parser_util:list_to_elixir_string(Reason)};
 format_reason({error, {_, _, Reason}}) ->
   format_reason(Reason);
 format_reason(Reason) when is_map(Reason) ->
@@ -141,10 +141,3 @@ ensure_quote_type_set(Value, QuoteType) ->
       maps:put(quote_type, QuoteType, Value)
   end.
 
-elixir_string_to_list(Text) when is_binary(Text) ->
-  'Elixir.String':to_charlist(Text).
-
-list_to_elixir_string(Text) when is_list(Text) ->
-  %% Ensure we're dealing with a flat list first
-  Text1 = lists:flatten(Text),
-  'Elixir.String.Chars':to_string(Text1).

--- a/src/piper_cmd2_parser_util.erl
+++ b/src/piper_cmd2_parser_util.erl
@@ -2,7 +2,9 @@
 
 -export([parse_token/3,
          parse_token/4,
-         new_ast/2]).
+         new_ast/2,
+         elixir_string_to_list/1,
+         list_to_elixir_string/1]).
 
 parse_token(Token, Name, Handler) ->
   parse_token(Token, Name, Name, Handler).
@@ -28,6 +30,15 @@ parse_token({_, {Line, _} = Position, Value}, Lexer, Parser, Handler) ->
   after
     'Elixir.Piper.Command.ParseContext':set_position(Context, Old)
   end.
+
+elixir_string_to_list(Text) when is_binary(Text) ->
+  'Elixir.String':to_charlist(Text).
+
+list_to_elixir_string(Text) when is_list(Text) ->
+  %% Ensure we're dealing with a flat list first
+  Text1 = lists:flatten(Text),
+  'Elixir.String.Chars':to_string(Text1).
+
 
 new_ast(Name, Args) ->
   apply(ast_node_for_name(Name), new, Args).

--- a/src/piper_cmd2_var_parser.yrl
+++ b/src/piper_cmd2_var_parser.yrl
@@ -46,15 +46,15 @@ index_value({integer, _, Value}) ->
   list_to_integer(Value).
 
 key_value({text, _, [$'|_]=Value}) ->
-  re:replace(Value, "^'|'$", "", [{return, binary}, global]);
+  re:replace(Value, "^'|'$", "", [{return, binary}, global, unicode]);
 key_value({text, _, [$"|_]=Value}) ->
-  re:replace(Value, "^\"|\"$", "", [{return, binary}, global]);
+  re:replace(Value, "^\"|\"$", "", [{return, binary}, global, unicode]);
 key_value({text, _, Value}) ->
-  list_to_binary(Value).
+  ?parser_util:list_to_elixir_string(Value).
 
 make_variable(Var) ->
   make_variable(Var, []).
 
 make_variable({variable, Position, Name}, Ops) ->
-  Var1 = {variable, Position, re:replace(Name, "^\\$", "", [{return, list}, global])},
+  Var1 = {variable, Position, re:replace(Name, "^\\$", "", [{return, list}, global, unicode])},
   ?new_ast(variable, [Var1, Ops]).


### PR DESCRIPTION
Adding inteprolated string support accidentally broke the case where a
quoted string contained a valid variable reference. This commit fixes
the bug and adds tests to prevent regressions in the future.

Fixes operable/cog#1135