### PR TITLE
Support interp strings and vars as redirect targets

### DIFF
--- a/lib/piper/command/ast/bind/pipeline.ex
+++ b/lib/piper/command/ast/bind/pipeline.ex
@@ -8,8 +8,8 @@ defimpl Piper.Common.Bindable, for: Piper.Command.Ast.Pipeline do
 
   def bind(pipeline, scope) do
     case Bindable.bind(pipeline.stages, scope) do
-      {:ok, updated_stages, scope} ->
-        {:ok, %{pipeline | stages: updated_stages}, scope}
+      {:ok, updated, scope} ->
+        {:ok, %{pipeline | stages: updated}, scope}
       error ->
         error
     end

--- a/lib/piper/command/ast/bind/redirect.ex
+++ b/lib/piper/command/ast/bind/redirect.ex
@@ -1,0 +1,58 @@
+defimpl Piper.Common.Bindable, for: Piper.Command.Ast.Redirect do
+
+  alias Piper.Command.Ast.Variable
+  alias Piper.Command.Ast.InterpolatedString
+  alias Piper.Common.Bindable
+
+  def resolve(redirect, scope) do
+    Enum.reduce_while(redirect.targets, {:ok, scope}, &resolve_target/2)
+  end
+
+  def bind(redirect, scope) do
+    case Enum.reduce_while(redirect.targets, {:ok, {[], scope}}, &bind_target/2) do
+      {:ok, {updated_targets, scope}} ->
+        with :ok <- Enum.reduce_while(updated_targets, :ok, &validate_target/2) do
+          {:ok, %{redirect | targets: Enum.reverse(updated_targets)}, scope}
+        end
+      error ->
+        error
+    end
+  end
+
+  defp resolve_target(target, {:ok, scope}) do
+    case Bindable.resolve(target, scope) do
+      {:ok, scope} ->
+        {:cont, {:ok, scope}}
+      error ->
+        {:halt, error}
+    end
+  end
+
+  defp bind_target(target, {:ok, {accum, scope}}) do
+    case Bindable.bind(target, scope) do
+      {:ok, updated, scope} ->
+        {:cont, {:ok, {[updated|accum], scope}}}
+      error ->
+        {:halt, error}
+    end
+  end
+
+  defp validate_target(%Variable{value: value}, acc) do
+    validate_target(value, acc)
+  end
+  defp validate_target(%InterpolatedString{}=target, acc) do
+    validate_target("#{target}", acc)
+  end
+  defp validate_target(value, _) when is_binary(value) do
+    if String.starts_with?(value, "chat:") do
+      if String.starts_with?(value, "chat://") do
+        {:cont, :ok}
+      else
+        {:halt, {:error, "URL redirect targets must begin with 'chat://'. Found '#{value}'."}}
+      end
+    else
+      {:cont, :ok}
+    end
+  end
+
+end

--- a/lib/piper/command/ast/pipeline.ex
+++ b/lib/piper/command/ast/pipeline.ex
@@ -2,25 +2,45 @@ defmodule Piper.Command.Ast.Pipeline do
 
   alias Piper.Command.Ast
 
-  defstruct [stages: nil, redirect_to: nil]
+  defstruct [stages: nil]
 
   def new(%Ast.PipelineStage{}=stages) do
-    pipeline = %__MODULE__{stages: stages}
-    redir = Enum.reduce(pipeline, nil, fn(invocation, _) -> invocation.redir end)
-    %{pipeline | redirect_to: redir}
+    %__MODULE__{stages: stages}
   end
 
   def to_stream(%__MODULE__{}=pipeline, chunk_size \\ 1) do
     Stream.chunk(pipeline, chunk_size)
   end
 
-  def redirect_targets(pipeline, default \\ nil) do
-    case pipeline.redirect_to do
-      nil ->
-        List.wrap(default)
-      redirect ->
-        Enum.map(redirect.targets, &(&1.value))
+  def redirect(%__MODULE__{}=pipeline) do
+    traverse(pipeline.stages, &get_redirects/1)
+  end
+
+  def raw_redirect_targets(%__MODULE__{}=pipeline) do
+    redirect = redirect(pipeline)
+    if redirect != nil do
+      Enum.map(redirect.targets, &("#{&1}"))
+    else
+      nil
     end
   end
+
+  defp traverse(%Ast.PipelineStage{right: right}=stage, tf) do
+    case tf.(stage) do
+      {:halt, value} ->
+        value
+      :cont ->
+        if right == nil do
+          nil
+        else
+          traverse(right, tf)
+        end
+    end
+  end
+
+  defp get_redirects(%Ast.PipelineStage{left: left, right: nil}) do
+    {:halt, left.redir}
+  end
+  defp get_redirects(_), do: :cont
 
 end

--- a/lib/piper/command/ast/pipeline_stage.ex
+++ b/lib/piper/command/ast/pipeline_stage.ex
@@ -63,4 +63,14 @@ defmodule Piper.Command.Ast.PipelineStage do
     %{stage | right: concatenate(right, new_stage, type)}
   end
 
+  def redirect_targets(%__MODULE__{right: right}) when right != nil,
+    do: nil
+  def redirect_targets(%__MODULE__{left: left}) do
+    if left.redir != nil do
+      Enum.map(left.redir.targets, &("#{&1}"))
+    else
+      nil
+    end
+  end
+
 end

--- a/test/command/parser/legacy_parser_test.exs
+++ b/test/command/parser/legacy_parser_test.exs
@@ -131,26 +131,26 @@ defmodule Parser.LegacyParserTest do
 
   test "Final redirects are stored on pipeline" do
     {:ok, ast} = Parser.scan_and_parse("foo > me | bar *> me ops")
-    assert ast.redirect_to != nil
-    assert Enum.count(ast.redirect_to.targets) == 2
-    assert Ast.Pipeline.redirect_targets(ast) == ["me", "ops"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["me", "ops"]
+    redirect = Ast.Pipeline.redirect(ast)
+    assert redirect != nil
+    assert Enum.count(redirect.targets) == 2
+    assert Enum.map(redirect.targets, &("#{&1}")) == ["me", "ops"]
   end
 
   test "URL-style redirect is parsed" do
     {:ok, ast} = Parser.scan_and_parse("foo | bar | baz > chat://#room1")
-    assert ast.redirect_to != nil
-    assert Enum.count(ast.redirect_to.targets) == 1
-    assert Ast.Pipeline.redirect_targets(ast) == ["chat://#room1"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["chat://#room1"]
+    redirect = Ast.Pipeline.redirect(ast)
+    assert redirect != nil
+    assert Enum.count(redirect.targets) == 1
+    assert Enum.map(redirect.targets, &("#{&1}")) == ["chat://#room1"]
   end
 
   test "URL-style redirects and non-URL redirects are parsed" do
     {:ok, ast} = Parser.scan_and_parse("foo | bar | baz *> ops chat://#dev")
-    assert ast.redirect_to != nil
-    assert Enum.count(ast.redirect_to.targets) == 2
-    assert Ast.Pipeline.redirect_targets(ast) == ["ops", "chat://#dev"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["ops", "chat://#dev"]
+    redirect = Ast.Pipeline.redirect(ast)
+    assert redirect != nil
+    assert Enum.count(redirect.targets) == 2
+    assert Enum.map(redirect.targets, &("#{&1}")) == ["ops", "chat://#dev"]
   end
 
   test "URL speling errors are caught :)" do

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -133,28 +133,42 @@ defmodule Parser.ParserTest do
     should_parse "foo:bar --baz *> dm ops", nil, 1
   end
 
-  test "Final redirects are stored on pipeline" do
+  test "Output redirect (single, variable)" do
+    should_parse "foo:bar --baz > $room", nil, 1
+  end
+
+  test "Output redirect (single, mixed)" do
+    should_parse "foo:bar --baz > #general $room", nil, 1
+  end
+
+  test "Output redirect (multi, variables)" do
+    should_parse "foo:bar --baz *> $room $user", nil, 1
+  end
+
+  test "Output redirect (multi, mixed)" do
+    should_parse "foo:bar --baz *> $room #general $users[1]", nil, 1
+  end
+
+  test "Pipeline redirects are stored on last stage" do
     {:ok, ast} = Parser.scan_and_parse("foo > me | bar *> me ops")
-    assert ast.redirect_to != nil
-    assert Enum.count(ast.redirect_to.targets) == 2
-    assert Ast.Pipeline.redirect_targets(ast) == ["me", "ops"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["me", "ops"]
+    redirect = Ast.Pipeline.redirect(ast)
+    assert redirect != nil
+    assert Enum.count(redirect.targets) == 2
+    assert Enum.map(redirect.targets, &("#{&1}")) == ["me", "ops"]
   end
 
   test "URL-style redirect is parsed" do
     {:ok, ast} = Parser.scan_and_parse("foo | bar | baz > chat://#room1")
-    assert ast.redirect_to != nil
-    assert Enum.count(ast.redirect_to.targets) == 1
-    assert Ast.Pipeline.redirect_targets(ast) == ["chat://#room1"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["chat://#room1"]
+    redirect = Ast.Pipeline.redirect(ast)
+    assert Enum.count(redirect.targets) == 1
+    assert Enum.map(redirect.targets, &("#{&1}")) == ["chat://#room1"]
   end
 
   test "URL-style redirects and non-URL redirects are parsed" do
     {:ok, ast} = Parser.scan_and_parse("foo | bar | baz *> ops chat://#dev")
-    assert ast.redirect_to != nil
-    assert Enum.count(ast.redirect_to.targets) == 2
-    assert Ast.Pipeline.redirect_targets(ast) == ["ops", "chat://#dev"]
-    assert Enum.map(ast.redirect_to.targets, &("#{&1}")) == ["ops", "chat://#dev"]
+    redirect = Ast.Pipeline.redirect(ast)
+    assert Enum.count(redirect.targets) == 2
+    assert Enum.map(redirect.targets, &("#{&1}")) == ["ops", "chat://#dev"]
   end
 
   test "URL speling errors are caught :)" do


### PR DESCRIPTION
This PR adds support for interpolated strings and variables as pipeline redirect targets. Prior to this change Piper parsed all redirect targets as string literals.

Here's an example which illustrates Piper's new behavior:

Let's assume we have a `$rooms` array variable containing the values `"ops"` and `"#general"`.

`echo Hello > $rooms[0]` expands to `echo Hello > ops`
`echo Hello > $rooms[1]` expands to `echo Hello > #general`
`echo Hello > '#${rooms[0]}'` expands to `echo Hello > #ops`

I added this branch as a dep override in Cog and verified this change doesn't break existing tests. Build details are [here](https://buildkite.com/operable/cog/builds/3905). Once this is merged I'll do the dep update dance with spanner and cog properly.

Fixes [cog/#1358](https://github.com/operable/cog/issues/1358)