### PR TITLE
Allow commands/bundles to start with uppercase letters.

### DIFF
--- a/src/piper_cmd2_name_lexer.xrl
+++ b/src/piper_cmd2_name_lexer.xrl
@@ -1,6 +1,6 @@
 Definitions.
 
-NAME                        = [a-z][a-zA-Z0-9_\-]*
+NAME                        = [a-zA-Z][a-zA-Z0-9_\-]*
 HIPCHAT_EMOJI               = \([a-zA-Z0-9_\-\+]+\)
 SLACK_EMOJI                 = :[a-zA-Z0-9_\-\+]+:
 COLON                       = :

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -337,6 +337,12 @@ defmodule Parser.ParserTest do
     {:error, "illegal characters \"\u1E23\""} = Parser.scan_and_parse("#{@unicode_text}:say_it 123")
   end
 
+  test "capitalized names should work" do
+    should_parse "Foo:bar"
+    should_parse "Foo:Bar"
+    should_parse "foo:Bar"
+  end
+
   test "malformed command names" do
     should_not_parse ":foo bar"
     should_not_parse "foo: bar"


### PR DESCRIPTION
This fixes https://github.com/operable/cog/issues/1373

I'm not sure if there is a specific reason to not allow commands/bundles to start with capital letters, but if not, this will make the error messages match whether the passed in command is `Foo` or `fOo`.