### PR TITLE
Improve error message for missing fully qualified command

### DIFF
--- a/lib/piper/command/ast/invocation.ex
+++ b/lib/piper/command/ast/invocation.ex
@@ -74,8 +74,8 @@ defmodule Piper.Command.Ast.Invocation do
               throw SemanticError.new(entity, {:ambiguous, bundles})
             {:error, :not_found} ->
               :not_found
-            {:error, {:not_in_bundle, _}} ->
-              :not_found
+            {:error, {:not_in_bundle, name}} ->
+              throw SemanticError.new(entity, {:not_in_bundle, name})
             {:error, error} ->
               throw SemanticError.new(entity, error)
           end

--- a/test/command/parser/parser_test.exs
+++ b/test/command/parser/parser_test.exs
@@ -204,7 +204,7 @@ defmodule Parser.ParserTest do
 
   test "commands not in the requested bundle fail resolution" do
     {:error, message} = Parser.scan_and_parse("not_in_bundle", TestHelpers.parser_options())
-    assert message == "Command 'not_in_bundle' not found in any installed bundle."
+    assert message == "Bundle 'bundle1' doesn't contain a command named 'not_in_bundle'."
   end
 
   test "splicing aliases into parse tree" do


### PR DESCRIPTION
No longer report a missing command as being the same as a missing fully qualified command.

This fixes: https://github.com/operable/cog/issues/899